### PR TITLE
Fix prepare:kovan NPM script (codegen after manifest template)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "deploy-beta": "yarn prepare:kovan && graph deploy graphprotocol/graph-network-beta --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy-testing": "yarn prepare:kovan && graph deploy davekaj/the-graph-kovan --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "prepare:addresses:kovan": "ts-node config/addressScript.ts && mustache ./config/generatedAddresses.json ./config/kovanAddresses.template.ts > ./config/addresses.ts",
-    "prepare:kovan": "yarn codegen && yarn prepare:addresses:kovan && mustache ./config/generatedAddresses.json subgraph.template.yaml > subgraph.yaml",
+    "prepare:kovan": "yarn prepare:addresses:kovan && mustache ./config/generatedAddresses.json subgraph.template.yaml > subgraph.yaml && yarn codegen",
     "lint": "yarn eslint .",
     "lint-fix": "eslint . --fix",
     "prettier": "prettier '**/*.ts'",


### PR DESCRIPTION
This fixes the order of creating `subgraph.yaml` from the template and running `graph codegen`. Otherwise, the command doesn't work in a fresh repository clone.