### PR TITLE
Add publicKey field to Channel entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -388,6 +388,8 @@ State channel allocation representing Indexer-SubgraphDeployment stake
 type Channel @entity {
   "Channel Address"
   id: ID!
+  "Uncompressed public key of the channel"
+  publicKey: Bytes!
   "Indexer of this channel"
   indexer: Indexer!
   "Subgraph deployment that is being staked on with an open channel"

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -144,6 +144,7 @@ export function handleAllocationCreated(event: AllocationCreated): void {
   // create channel
   let channel = new Channel(channelID)
   channel.indexer = indexerID
+  channel.publicKey = event.params.channelPubKey
   channel.subgraphDeployment = subgraphDeploymentID
   channel.allocation = allocationID
   channel.tokensAllocated = event.params.tokens


### PR DESCRIPTION
This adds a `publicKey: Bytes!` field to `Channel`. It is set by reading the `channelPubKey` parameter of the `AllocationCreated` event when the `Channel` entity is first created.

This field is required to calculate the public channel identifier for Connext (`indra...`), which is then used as the recipient in payments.