### PR TITLE
Keep track of the blocks each allocation was created at and closed at 

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -1,4 +1,4 @@
 {
-    "subgraphDeploymentID": "QmNosTNqEb8e63PAS1WkLTbVBjU5UmqeMsmxjdSXpQLEuy",
-    "deploymentTime": "October 6th 9:26 EST, 2020"
+    "subgraphDeploymentID": "QmWGysbVgK6i2dkRJaLfrEscErg8Bv8SmLXTajM41p3HiM",
+    "deploymentTime": "October 8th 12:35pm EST, 2020"
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -320,7 +320,7 @@ type SubgraphVersion @entity {
 The immutable subgraph deployment defined by a subgraph manifest
 """
 type SubgraphDeployment @entity {
-  "Subgraph Deployment ID"
+  "Subgraph Deployment ID. The IPFS hash with Qm removed to fit into 32 bytes"
   id: ID!
   "The versions this subgraph deployment relates to"
   versions: [SubgraphVersion!]! @derivedFrom(field: "subgraphDeployment")
@@ -436,8 +436,8 @@ type Indexer @entity {
   delegatorParameterCooldown: Int!
   "Block number for the last time the delegator updated their parameters"
   lastDelegationParameterUpdate: Int!
-  "Count of how many times this indexer has been forced to settle"
-  forcedSettlements: Int!
+  "Count of how many times this indexer has been forced to close an allocation"
+  forcedClosures: Int!
 
   # Metrics
   "Total return this indexer has earned"
@@ -462,7 +462,7 @@ type Allocation @entity {
   subgraphDeployment: SubgraphDeployment!
   "Tokens associated with the allocation"
   allocatedTokens: BigInt!
-  "Effective allocation that is realized upon settling"
+  "Effective allocation that is realized upon closing"
   effectiveAllocation: BigInt!
   "Epoch this allocation was created"
   createdAtEpoch: Int!
@@ -471,7 +471,7 @@ type Allocation @entity {
   "Epoch this allocation was closed in"
   closedAtEpoch: Int!
   "Block at which this allocation was closed"
-  closedAtBlock: Bytes
+  closedAtBlockHash: Bytes
   "Fees this allocation collected from query fees upon closing. Excludes curator reward and rebate claimed"
   queryFeesCollected: BigInt!
   "Rebate amount claimed from the protocol"
@@ -480,15 +480,15 @@ type Allocation @entity {
   curatorRewards: BigInt!
   "Indexing rewards earned by this allocation"
   indexingRewards: BigInt!
-  "Pool in which this allocation was settled"
-  poolSettledIn: Pool
+  "Pool in which this allocation was closed"
+  poolClosedIn: Pool
   "Fees paid out to delegators"
   delegationFees: BigInt!
   "Status of the allocation"
   status: AllocationStatus!
   "Timestamp this allocation was created at"
   createdAt: Int!
-  "POI submitted with a settlement"
+  "POI submitted with a closed allocation"
   poi: Bytes
 
   # Metrics
@@ -504,18 +504,18 @@ type Allocation @entity {
 enum AllocationStatus {
   Null # == indexer == address(0)
   Active # == not Null && tokens > 0
-  Settled # == Active && settledAtEpoch != 0
-  Finalized # == Settling && settledAtEpoch + channelDisputeEpochs > now(). Note, this never happens in practice, because it is implied
+  Closed # == Active && closedAtEpoch != 0
+  Finalized # == Closing && closedAtEpoch + channelDisputeEpochs > now(). Note, this never happens in practice, because it is implied
   Claimed # == not Null && tokens == 0 - i.e. finalized, and all tokens withdrawn
 }
 
 """
-Global pool of query fees for settled state channels. There is one pool per epoch
+Global pool of query fees for closed state channels. There is one pool per epoch
 """
 type Pool @entity {
   "Epoch number of the pool"
   id: ID!
-  "Total allocation settled in this epoch - includes all effective allocation"
+  "Total allocations closed in this epoch - includes all effective allocation"
   allocation: BigInt!
   "Total query fees collected in this epoch"
   totalQueryFees: BigInt!
@@ -523,8 +523,8 @@ type Pool @entity {
   claimedFees: BigInt!
   "Total rewards deposited to all curator bonding curves during the epoch"
   curatorRewards: BigInt!
-  "Allocations that were settled during this epoch"
-  settledAllocations: [Allocation!]! @derivedFrom(field: "poolSettledIn")
+  "Allocations that were closed during this epoch"
+  closedAllocations: [Allocation!]! @derivedFrom(field: "poolClosedIn")
 }
 
 """

--- a/src/mappings/curation.ts
+++ b/src/mappings/curation.ts
@@ -99,7 +99,7 @@ export function handleBurned(event: Burned): void {
  * @dev handleCollected
  *  - updates subgraph - TODO - we might add curator earned to this. but it seems really hard
  *  - @note - we do not update totalQueryFeesCollected here, because it is already updated in
- *    staking.handleAllocationSettled()
+ *    staking.handleAllocationClosed()
  */
 export function handleCollected(event: Collected): void {
   // update subgraph

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -110,7 +110,7 @@ export function createOrLoadIndexer(id: string, timestamp: BigInt): Indexer {
     indexer.queryFeeCut = 0
     indexer.delegatorParameterCooldown = 0
     indexer.lastDelegationParameterUpdate = 0
-    indexer.forcedSettlements = 0
+    indexer.forcedClosures = 0
 
     indexer.totalReturn = BigDecimal.fromString('0')
     indexer.annualizedReturn = BigDecimal.fromString('0')


### PR DESCRIPTION
The block in which an allocation was created is needed for generating POIs to be submitted when closing an allocation. 
The closed at epoch will be used to monitor for allocations that are available for their rewards to be claimed.