### PR TITLE
Add field closedAtBlockNumber to Allocation entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -547,6 +547,8 @@ type Allocation @entity {
   closedAtEpoch: Int!
   "Block at which this allocation was closed"
   closedAtBlockHash: Bytes
+  "Block at which this allocation was closed"
+  closedAtBlockNumber: Int
   "Fees this allocation collected from query fees upon closing. Excludes curator reward and rebate claimed"
   queryFeesCollected: BigInt!
   "Rebate amount claimed from the protocol"

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -429,6 +429,7 @@ export function handleAllocationClosed(event: AllocationClosed): void {
   allocation.activeForIndexer = null
   allocation.closedAtEpoch = event.params.epoch.toI32()
   allocation.closedAtBlockHash = event.block.hash
+  allocation.closedAtBlockNumber = event.block.number
   allocation.effectiveAllocation = event.params.effectiveAllocation
   allocation.status = 'Closed'
   allocation.poi = event.params.poi


### PR DESCRIPTION
`ClosedAtBlockNumber` is needed to filter allocations for the potential POI disputes monitoring tool. 