### PR TITLE
Added lastDelegatedAt and lastUndelegatedAt

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -660,6 +660,10 @@ type DelegatedStake @entity {
   realizedRewards: BigDecimal!
   "Time this delegator first delegated to an indexer"
   createdAt: Int!
+  "Last time this delegator delegated towards this indexer"
+  lastDelegatedAt: Int
+  "Last time this delegator undelegated from this indexer"
+  lastUndelegatedAt: Int
 }
 
 """

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -209,6 +209,7 @@ export function handleStakeDelegated(event: StakeDelegated): void {
 
   delegatedStake.stakedTokens = delegatedStake.stakedTokens.plus(event.params.tokens)
   delegatedStake.shareAmount = delegatedStake.shareAmount.plus(event.params.shares)
+  delegatedStake.lastDelegatedAt = event.block.timestamp.toI32();
   delegatedStake.save()
 
   // upgrade graph network
@@ -241,6 +242,7 @@ export function handleStakeDelegatedLocked(event: StakeDelegatedLocked): void {
   delegatedStake.shareAmount = delegatedStake.shareAmount.minus(event.params.shares)
   delegatedStake.lockedTokens = delegatedStake.lockedTokens.plus(event.params.tokens)
   delegatedStake.lockedUntil = event.params.until.toI32() // until always updates and overwrites the past lockedUntil time
+  delegatedStake.lastUndelegatedAt = event.block.timestamp.toI32();
 
   let realizedRewards = event.params.shares
     .toBigDecimal()


### PR DESCRIPTION
This change adds a simple timestamp tracking of the last time a stake was delegated/undelegated. [Currently indexing here](https://thegraph.com/explorer/subgraph/juanmardefago/dev-subgraph?query=Stakes%20lastDelegated%20and%20lastUndelegated)