### PR TITLE
Added Networks and Categories

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -323,6 +323,30 @@ type Subgraph @entity {
   website: String
   "Display name"
   displayName: String
+  "Network name"
+  network: Network
+  "Categories that the subgraph belongs to. Modelled with a relation to allow for many-to-many relationship querying"
+  categories: [SubgraphCategoryRelation!]! @derivedFrom(field:"subgraph")
+}
+
+type Network @entity {
+  id: ID!
+
+  subgraphs: [Subgraph!]! @derivedFrom(field:"network")
+}
+
+type SubgraphCategoryRelation @entity {
+  id: ID!
+
+  subgraph: Subgraph!
+
+  category: SubgraphCategory!
+}
+
+type SubgraphCategory @entity {
+  id: ID!
+
+  subgraphs: [SubgraphCategoryRelation!]! @derivedFrom(field:"category")
 }
 
 """

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -14,6 +14,9 @@ import {
   NameSignal,
   Delegator,
   DelegatedStake,
+  Network,
+  SubgraphCategory,
+  SubgraphCategoryRelation,
 } from '../types/schema'
 import { ENS } from '../types/GNS/ENS'
 import { Controller } from '../types/Controller/Controller'
@@ -41,11 +44,6 @@ export function createOrLoadSubgraph(
     subgraph.withdrawnTokens = BigInt.fromI32(0)
 
     subgraph.metadataHash = Bytes.fromI32(0) as Bytes
-    subgraph.description = ''
-    subgraph.image = ''
-    subgraph.codeRepository = ''
-    subgraph.website = ''
-    subgraph.displayName = ''
 
     subgraph.save()
 
@@ -686,4 +684,37 @@ export function calculatePricePerShare(deployment: SubgraphDeployment): BigDecim
           .div(deployment.signalAmount.toBigDecimal())
           .truncate(18)
   return pricePerShare
+}
+
+export function createOrLoadNetwork(id: String): Network {
+  let network = Network.load(id)
+  if(network == null) {
+    network = new Network(id)
+
+    network.save()
+  }
+  return network as Network;
+}
+
+export function createOrLoadSubgraphCategory(id: String): SubgraphCategory {
+  let category = SubgraphCategory.load(id)
+  if(category == null) {
+    category = new SubgraphCategory(id)
+
+    category.save()
+  }
+  return category as SubgraphCategory;
+}
+
+export function createOrLoadSubgraphCategoryRelation(categoryId: String, subgraphId: String): SubgraphCategoryRelation {
+  let id = joinID([categoryId, subgraphId])
+  let relation = SubgraphCategoryRelation.load(id)
+  if(relation == null) {
+    relation = new SubgraphCategoryRelation(id)
+    relation.subgraph = subgraphId
+    relation.category = categoryId
+
+    relation.save()
+  }
+  return relation as SubgraphCategoryRelation;
 }

--- a/src/mappings/metadataHelpers.template.ts
+++ b/src/mappings/metadataHelpers.template.ts
@@ -1,6 +1,7 @@
-import { json, ipfs, Bytes, JSONValueKind } from '@graphprotocol/graph-ts'
+import { json, ipfs, Bytes, JSONValueKind, log } from '@graphprotocol/graph-ts'
 import { GraphAccount, Subgraph, SubgraphVersion } from '../types/schema'
 import { jsonToString } from './utils'
+import { createOrLoadSubgraphCategory, createOrLoadSubgraphCategoryRelation, createOrLoadNetwork } from './helpers'
 
 export function fetchGraphAccountMetadata(graphAccount: GraphAccount, ipfsHash: string): void {
   {{#ipfs}}
@@ -33,12 +34,23 @@ export function fetchSubgraphMetadata(subgraph: Subgraph, ipfsHash: string): Sub
       subgraph.displayName = jsonToString(data.get('displayName'))
       subgraph.codeRepository = jsonToString(data.get('codeRepository'))
       subgraph.website = jsonToString(data.get('website'))
-    } else {
-      subgraph.description = ''
-      subgraph.image = ''
-      subgraph.displayName = ''
-      subgraph.codeRepository = ''
-      subgraph.website = ''
+      let networkId = jsonToString(data.get('network'))
+      if(networkId != '') {
+        createOrLoadNetwork(networkId)
+        subgraph.network = networkId
+      }
+
+      let categories = data.get('categories')
+
+      if(categories != null) {
+        let categoriesArray = categories.toArray()
+
+        for(let i = 0; i < categoriesArray.length; i++) {
+          let categoryId = jsonToString(categoriesArray[i])
+          createOrLoadSubgraphCategory(categoryId)
+          createOrLoadSubgraphCategoryRelation(categoryId, subgraph.id)
+        }
+      }
     }
   }
   {{/ipfs}}


### PR DESCRIPTION
Addition to the `Subgraph` entity. Read the data from the same IPFS file as the rest of the metadata for the subgraphs, so it's only gonna be enabled for IPFS-enabled deployments