### PR TITLE
NameSignal refactor and a few improvements

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -320,6 +320,8 @@ type Subgraph @entity {
   currentSignalledTokens: BigInt!
   "The CURRENT name signal amount for this subgraph"
   nameSignalAmount: BigInt!
+  "Current amount of version signal managed by the name pool"
+  signalAmount: BigInt!
   "Reserve ratio of the name curation curve. In parts per million"
   reserveRatio: Int!
   "Tokens that can be withdrawn once the Subgraph is deprecated"

--- a/schema.graphql
+++ b/schema.graphql
@@ -330,6 +330,8 @@ type Subgraph @entity {
   withdrawnTokens: BigInt!
   "Curators of this subgraph deployment"
   nameSignals: [NameSignal!]! @derivedFrom(field: "subgraph")
+  "Total amount of NameSignal entities"
+  nameSignalCount: Int!
 
   # Metadata from IPFS linked in GNS
   "Subgraph metadata"
@@ -882,6 +884,18 @@ type NameSignal @entity {
   signalAverageCostBasis: BigDecimal!
   "signalAverageCostBasis / signal"
   signalAverageCostBasisPerSignal: BigDecimal!
+}
+
+"""
+Auxiliary entity to be able to batch update NameSignal entities
+"""
+type NameSignalSubgraphRelation @entity {
+  "Subgraph ID + index"
+  id:ID!
+
+  nameSignal: NameSignal!
+
+  subgraph: Subgraph!
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -865,7 +865,7 @@ type NameSignal @entity {
   "Shares of the name pool (GNS) that the curator has from signaling their GRT"
   nameSignal: BigInt!
   "Actual signal shares that the name pool minted with the GRT provided by the curator"
-  signal: BigInt!
+  signal: BigDecimal!
 
   # Metrics
   "Block for which the curator last entered or exited the curve"
@@ -874,6 +874,11 @@ type NameSignal @entity {
   # unrealized gains for their current balance, based on the time since the last exit/entry of the curve
   "Summation of realized rewards from before the last time the curator entered the curation curve"
   realizedRewards: BigInt!
+
+  "[DEPRECATED] Curator average cost basis for this name signal on this subgraph. New field for further versions will be nameSignalAverageCostBasis"
+  averageCostBasis: BigDecimal! # note this is ONLY name signal. This is okay for the protocol for now
+  "[DEPRECATED] nameSignalAverageCostBasis / nameSignal. New field for further versions will be nameSignalAverageCostBasisPerSignal"
+  averageCostBasisPerSignal: BigDecimal!
 
   "Curator average cost basis for this name signal on this subgraph"
   nameSignalAverageCostBasis: BigDecimal! # note this is ONLY name signal. This is okay for the protocol for now

--- a/schema.graphql
+++ b/schema.graphql
@@ -316,6 +316,8 @@ type Subgraph @entity {
   signalledTokens: BigInt!
   "CUMULATIVE unsignalled tokens on this subgraph all time"
   unsignalledTokens: BigInt!
+  "CURRENT amount of tokens signalled on this subgraph. Only accounts for signalling done through GNS (name signalling)"
+  currentSignalledTokens: BigInt!
   "The CURRENT name signal amount for this subgraph"
   nameSignalAmount: BigInt!
   "Reserve ratio of the name curation curve. In parts per million"
@@ -772,15 +774,16 @@ type Curator @entity {
   totalReturn: BigDecimal!
   "NOT IMPLEMENTED - Signaling efficiency of the curator"
   signalingEfficiency: BigDecimal!
+
   "CURRENT summed name signal for all bonding curves"
   totalNameSignal: BigDecimal!
-  "Total curator cost basis of all shares purchased on all bonding curves"
+  "Total curator cost basis of all shares of name pools purchased on all bonding curves"
   totalNameSignalAverageCostBasis: BigDecimal!
   "totalNameSignalAverageCostBasis / totalNameSignal"
   totalAverageCostBasisPerNameSignal: BigDecimal!
   "CURRENT summed signal for all bonding curves"
   totalSignal: BigDecimal!
-  "Total curator cost basis of all shares purchased on all bonding curves"
+  "Total curator cost basis of all version signal shares purchased on all bonding curves. Includes those purchased through GNS name pools"
   totalSignalAverageCostBasis: BigDecimal!
   "totalSignalAverageCostBasis / totalSignal"
   totalAverageCostBasisPerSignal: BigDecimal!
@@ -855,10 +858,10 @@ type NameSignal @entity {
   unsignalledTokens: BigInt!
   "Tokens the curator has withdrawn from a deprecated name curve"
   withdrawnTokens: BigInt!
-  "Signal that the curator has from signaling their GRT"
+  "Shares of the name pool (GNS) that the curator has from signaling their GRT"
   nameSignal: BigInt!
-  # Note , we don't show vSignal here. We could, but it has almost no value to display it.
-  # We can get away with using curator nameSignal, total n and v signal on the subgraph.
+  "Actual signal shares that the name pool minted with the GRT provided by the curator"
+  signal: BigInt!
 
   # Metrics
   "Block for which the curator last entered or exited the curve"
@@ -867,10 +870,16 @@ type NameSignal @entity {
   # unrealized gains for their current balance, based on the time since the last exit/entry of the curve
   "Summation of realized rewards from before the last time the curator entered the curation curve"
   realizedRewards: BigInt!
+
   "Curator average cost basis for this name signal on this subgraph"
-  averageCostBasis: BigDecimal! # note this is ONLY name signal. This is okay for the protocol for now
-  "averageCostBasis / nameSignal"
-  averageCostBasisPerSignal: BigDecimal!
+  nameSignalAverageCostBasis: BigDecimal! # note this is ONLY name signal. This is okay for the protocol for now
+  "nameSignalAverageCostBasis / nameSignal"
+  nameSignalAverageCostBasisPerSignal: BigDecimal!
+
+  "Curator average cost basis for the version signal on this subgraph name pool"
+  signalAverageCostBasis: BigDecimal!
+  "signalAverageCostBasis / signal"
+  signalAverageCostBasisPerSignal: BigDecimal!
 }
 
 """

--- a/src/mappings/curation.ts
+++ b/src/mappings/curation.ts
@@ -67,15 +67,11 @@ export function handleSignalled(event: Signalled): void {
   signal.signal = signal.signal.plus(event.params.signal)
   signal.lastUpdatedAt = event.block.timestamp.toI32()
   signal.lastUpdatedAtBlock = event.block.number.toI32()
-  signal.averageCostBasis = signal.averageCostBasis.plus(
-    event.params.tokens.toBigDecimal(),
-  )
+  signal.averageCostBasis = signal.averageCostBasis.plus(event.params.tokens.toBigDecimal())
 
   // zero division protection
   if (signal.signal.toBigDecimal() != zeroBD) {
-    signal.averageCostBasisPerSignal = signal.averageCostBasis.div(
-      signal.signal.toBigDecimal(),
-    )
+    signal.averageCostBasisPerSignal = signal.averageCostBasis.div(signal.signal.toBigDecimal())
   }
   signal.save()
 
@@ -175,7 +171,7 @@ export function handleBurned(event: Burned): void {
     )
   }
 
-  if(isSignalBecomingInactive) {
+  if (isSignalBecomingInactive) {
     curator.activeSignalCount = curator.activeSignalCount - 1
     curator.activeCombinedSignalCount = curator.activeCombinedSignalCount - 1
   }

--- a/src/mappings/curation.ts
+++ b/src/mappings/curation.ts
@@ -155,6 +155,7 @@ export function handleBurned(event: Burned): void {
   signal.averageCostBasis = signal.signal
     .toBigDecimal()
     .times(signal.averageCostBasisPerSignal)
+    .truncate(18)
   let diffACB = previousACB.minus(signal.averageCostBasis)
   if (signal.averageCostBasis == zeroBD) {
     signal.averageCostBasisPerSignal = zeroBD

--- a/src/mappings/gns.ts
+++ b/src/mappings/gns.ts
@@ -24,6 +24,8 @@ import {
   SubgraphDeployment,
   GraphNetwork,
   GraphAccount,
+  NameSignalSubgraphRelation,
+  NameSignal,
 } from '../types/schema'
 
 import { zeroBD } from './utils'
@@ -402,17 +404,56 @@ export function handleNameSignalUpgrade(event: NameSignalUpgrade): void {
   let subgraphID = joinID([graphAccount, subgraphNumber])
   let subgraph = Subgraph.load(subgraphID)
 
-  // event.params.newVSignalCreated -> will be used to calculate new nSignal/vSignal ratio
-
   // Weirdly here, we add the token amount to both, but also the name curator owner must
   // stake the withdrawal fees, so both balance fairly
   // TODO - will have to come back here and make sure my thinking is correct
+  // event.params.newVSignalCreated -> will be used to calculate new nSignal/vSignal ratio
   subgraph.signalAmount = event.params.newVSignalCreated
   subgraph.unsignalledTokens = subgraph.unsignalledTokens.plus(event.params.tokensSignalled)
   subgraph.signalledTokens = subgraph.signalledTokens.plus(event.params.tokensSignalled)
   subgraph.save()
 
   let signalRatio = subgraph.signalAmount / subgraph.nameSignalAmount
+
+  for(let i = 0; i < subgraph.nameSignalCount; i++) {
+    let relation = NameSignalSubgraphRelation.load(joinID([subgraphID, BigInt.fromI32(i).toString()]))
+    let nameSignal = NameSignal.load(relation.nameSignal)
+    if(!nameSignal.nameSignal.isZero()) {
+      let curator = Curator.load(nameSignal.curator)
+
+      let oldSignal = nameSignal.signal;
+      nameSignal.signal = nameSignal.nameSignal * signalRatio
+
+      // zero division protection
+      if (nameSignal.signal.toBigDecimal() != zeroBD) {
+        nameSignal.signalAverageCostBasisPerSignal = nameSignal.signalAverageCostBasis.div(
+          nameSignal.signal.toBigDecimal(),
+        )
+      }
+
+      let previousACBSignal = nameSignal.signalAverageCostBasis
+      nameSignal.signalAverageCostBasis = nameSignal.signal
+        .toBigDecimal()
+        .times(nameSignal.signalAverageCostBasisPerSignal)
+
+      let diffACBSignal = previousACBSignal.minus(nameSignal.signalAverageCostBasis)
+      if (nameSignal.signalAverageCostBasis == zeroBD) {
+        nameSignal.signalAverageCostBasisPerSignal = zeroBD
+      }
+
+      curator.totalSignal = curator.totalSignal.minus(oldSignal.toBigDecimal()).plus(nameSignal.signal.toBigDecimal())
+      curator.totalSignalAverageCostBasis = curator.totalSignalAverageCostBasis.minus(diffACBSignal)
+      if (curator.totalSignal == zeroBD) {
+        curator.totalAverageCostBasisPerSignal = zeroBD
+      } else {
+        curator.totalAverageCostBasisPerSignal = curator.totalSignalAverageCostBasis.div(
+          curator.totalSignal,
+        )
+      }
+      nameSignal.save()
+      curator.save()
+    }
+  }
 }
 
 // Only need to upgrade withdrawable tokens. Everything else handled from

--- a/src/mappings/gns.ts
+++ b/src/mappings/gns.ts
@@ -198,6 +198,7 @@ export function handleNSignalMinted(event: NSignalMinted): void {
   let subgraph = Subgraph.load(subgraphID)
 
   subgraph.nameSignalAmount = subgraph.nameSignalAmount.plus(event.params.nSignalCreated)
+  subgraph.signalAmount = subgraph.signalAmount.plus(event.params.vSignalCreated)
   subgraph.signalledTokens = subgraph.signalledTokens.plus(event.params.tokensDeposited)
   subgraph.currentSignalledTokens = subgraph.currentSignalledTokens.plus(event.params.tokensDeposited)
   subgraph.save()
@@ -302,6 +303,7 @@ export function handleNSignalBurned(event: NSignalBurned): void {
   let subgraph = Subgraph.load(subgraphID)
 
   subgraph.nameSignalAmount = subgraph.nameSignalAmount.minus(event.params.nSignalBurnt)
+  subgraph.signalAmount = subgraph.signalAmount.minus(event.params.vSignalBurnt)
   subgraph.unsignalledTokens = subgraph.unsignalledTokens.plus(event.params.tokensReceived)
   subgraph.currentSignalledTokens = subgraph.currentSignalledTokens.minus(event.params.tokensReceived)
   subgraph.save()
@@ -400,12 +402,17 @@ export function handleNameSignalUpgrade(event: NameSignalUpgrade): void {
   let subgraphID = joinID([graphAccount, subgraphNumber])
   let subgraph = Subgraph.load(subgraphID)
 
+  // event.params.newVSignalCreated -> will be used to calculate new nSignal/vSignal ratio
+
   // Weirdly here, we add the token amount to both, but also the name curator owner must
   // stake the withdrawal fees, so both balance fairly
   // TODO - will have to come back here and make sure my thinking is correct
+  subgraph.signalAmount = event.params.newVSignalCreated
   subgraph.unsignalledTokens = subgraph.unsignalledTokens.plus(event.params.tokensSignalled)
   subgraph.signalledTokens = subgraph.signalledTokens.plus(event.params.tokensSignalled)
   subgraph.save()
+
+  let signalRatio = subgraph.signalAmount / subgraph.nameSignalAmount
 }
 
 // Only need to upgrade withdrawable tokens. Everything else handled from
@@ -416,6 +423,7 @@ export function handleNameSignalDisabled(event: NameSignalDisabled): void {
   let subgraphID = joinID([graphAccount, subgraphNumber])
   let subgraph = Subgraph.load(subgraphID)
   subgraph.withdrawableTokens = event.params.withdrawableGRT
+  subgraph.signalAmount = BigInt.fromI32(0)
   subgraph.save()
 }
 

--- a/src/mappings/gns.ts
+++ b/src/mappings/gns.ts
@@ -331,6 +331,7 @@ export function handleNSignalBurned(event: NSignalBurned): void {
   nameSignal.nameSignalAverageCostBasis = nameSignal.nameSignal
     .toBigDecimal()
     .times(nameSignal.nameSignalAverageCostBasisPerSignal)
+    .truncate(18)
   let diffACBNameSignal = previousACBNameSignal.minus(nameSignal.nameSignalAverageCostBasis)
   if (nameSignal.nameSignalAverageCostBasis == BigDecimal.fromString('0')) {
     nameSignal.nameSignalAverageCostBasisPerSignal = BigDecimal.fromString('0')
@@ -357,6 +358,7 @@ export function handleNSignalBurned(event: NSignalBurned): void {
   nameSignal.signalAverageCostBasis = nameSignal.signal
     .toBigDecimal()
     .times(nameSignal.signalAverageCostBasisPerSignal)
+    .truncate(18)
   let diffACBSignal = previousACBSignal.minus(nameSignal.signalAverageCostBasis)
   if (nameSignal.signalAverageCostBasis == zeroBD) {
     nameSignal.signalAverageCostBasisPerSignal = zeroBD
@@ -435,6 +437,7 @@ export function handleNameSignalUpgrade(event: NameSignalUpgrade): void {
       nameSignal.signalAverageCostBasis = nameSignal.signal
         .toBigDecimal()
         .times(nameSignal.signalAverageCostBasisPerSignal)
+        .truncate(18)
 
       let diffACBSignal = previousACBSignal.minus(nameSignal.signalAverageCostBasis)
       if (nameSignal.signalAverageCostBasis == zeroBD) {

--- a/src/mappings/gns.ts
+++ b/src/mappings/gns.ts
@@ -199,10 +199,12 @@ export function handleNSignalMinted(event: NSignalMinted): void {
 
   subgraph.nameSignalAmount = subgraph.nameSignalAmount.plus(event.params.nSignalCreated)
   subgraph.signalledTokens = subgraph.signalledTokens.plus(event.params.tokensDeposited)
+  subgraph.currentSignalledTokens = subgraph.currentSignalledTokens.plus(event.params.tokensDeposited)
   subgraph.save()
 
   // Update the curator
-  let curator = createOrLoadCurator(curatorID, event.block.timestamp)
+  let curator = createOrLoadCurator(event.params.nameCurator.toHexString(), event.block.timestamp)
+  // nSignal
   curator.totalNameSignalledTokens = curator.totalNameSignalledTokens.plus(
     event.params.tokensDeposited,
   )
@@ -217,6 +219,23 @@ export function handleNSignalMinted(event: NSignalMinted): void {
       curator.totalNameSignal,
     )
   }
+
+  // vSignal
+  // Might need to add the curation tax to this specific case
+  curator.totalSignalledTokens = curator.totalSignalledTokens.plus(
+    event.params.tokensDeposited,
+  )
+  curator.totalSignalAverageCostBasis = curator.totalSignalAverageCostBasis.plus(
+    event.params.tokensDeposited.toBigDecimal(),
+  )
+  curator.totalSignal = curator.totalSignal.plus(event.params.vSignalCreated.toBigDecimal())
+
+  // zero division protection
+  if (curator.totalSignal != zeroBD) {
+    curator.totalAverageCostBasisPerSignal = curator.totalSignalAverageCostBasis.div(
+      curator.totalSignal,
+    )
+  }
   curator.save()
 
   let nameSignal = createOrLoadNameSignal(curatorID, subgraphID, event.block.timestamp)
@@ -225,24 +244,37 @@ export function handleNSignalMinted(event: NSignalMinted): void {
     nameSignal.nameSignal.isZero() && !event.params.nSignalCreated.isZero()
 
   nameSignal.nameSignal = nameSignal.nameSignal.plus(event.params.nSignalCreated)
+  nameSignal.signal = nameSignal.signal.plus(event.params.vSignalCreated)
   nameSignal.signalledTokens = nameSignal.signalledTokens.plus(event.params.tokensDeposited)
   nameSignal.lastNameSignalChange = event.block.timestamp.toI32()
-  nameSignal.averageCostBasis = nameSignal.averageCostBasis.plus(
+  // nSignal
+  nameSignal.nameSignalAverageCostBasis = nameSignal.nameSignalAverageCostBasis.plus(
     event.params.tokensDeposited.toBigDecimal(),
   )
 
   // zero division protection
   if (nameSignal.nameSignal.toBigDecimal() != zeroBD) {
-    nameSignal.averageCostBasisPerSignal = nameSignal.averageCostBasis.div(
+    nameSignal.nameSignalAverageCostBasisPerSignal = nameSignal.nameSignalAverageCostBasis.div(
       nameSignal.nameSignal.toBigDecimal(),
+    )
+  }
+
+  // vSignal
+  nameSignal.signalAverageCostBasis = nameSignal.signalAverageCostBasis.plus(
+    event.params.tokensDeposited.toBigDecimal(),
+  )
+
+  // zero division protection
+  if (nameSignal.signal.toBigDecimal() != zeroBD) {
+    nameSignal.signalAverageCostBasisPerSignal = nameSignal.signalAverageCostBasis.div(
+      nameSignal.signal.toBigDecimal(),
     )
   }
   nameSignal.save()
 
   // reload curator, since it might update counters in another context and we don't want to overwrite it
   curator = Curator.load(curatorID) as Curator
-
-  if (isNameSignalBecomingActive) {
+  if(isNameSignalBecomingActive) {
     curator.activeNameSignalCount = curator.activeNameSignalCount + 1
     curator.activeCombinedSignalCount = curator.activeCombinedSignalCount + 1
   }
@@ -271,6 +303,7 @@ export function handleNSignalBurned(event: NSignalBurned): void {
 
   subgraph.nameSignalAmount = subgraph.nameSignalAmount.minus(event.params.nSignalBurnt)
   subgraph.unsignalledTokens = subgraph.unsignalledTokens.plus(event.params.tokensReceived)
+  subgraph.currentSignalledTokens = subgraph.currentSignalledTokens.minus(event.params.tokensReceived)
   subgraph.save()
 
   // update name signal
@@ -284,19 +317,20 @@ export function handleNSignalBurned(event: NSignalBurned): void {
     !nameSignal.nameSignal.isZero() && event.params.nSignalBurnt == nameSignal.nameSignal
 
   nameSignal.nameSignal = nameSignal.nameSignal.minus(event.params.nSignalBurnt)
+  nameSignal.signal = nameSignal.signal.minus(event.params.vSignalBurnt)
   nameSignal.unsignalledTokens = nameSignal.unsignalledTokens.plus(event.params.tokensReceived)
   nameSignal.lastNameSignalChange = event.block.timestamp.toI32()
 
+  // nSignal ACB
   // update acb to reflect new name signal balance
-  let previousACB = nameSignal.averageCostBasis
-  nameSignal.averageCostBasis = nameSignal.nameSignal
+  let previousACBNameSignal = nameSignal.nameSignalAverageCostBasis
+  nameSignal.nameSignalAverageCostBasis = nameSignal.nameSignal
     .toBigDecimal()
-    .times(nameSignal.averageCostBasisPerSignal)
-  let diffACB = previousACB.minus(nameSignal.averageCostBasis)
-  if (nameSignal.averageCostBasis == BigDecimal.fromString('0')) {
-    nameSignal.averageCostBasisPerSignal = BigDecimal.fromString('0')
+    .times(nameSignal.nameSignalAverageCostBasisPerSignal)
+  let diffACBNameSignal = previousACBNameSignal.minus(nameSignal.nameSignalAverageCostBasis)
+  if (nameSignal.nameSignalAverageCostBasis == BigDecimal.fromString('0')) {
+    nameSignal.nameSignalAverageCostBasisPerSignal = BigDecimal.fromString('0')
   }
-  nameSignal.save()
 
   // update curator
   let curator = createOrLoadCurator(event.params.nameCurator.toHexString(), event.block.timestamp)
@@ -304,7 +338,7 @@ export function handleNSignalBurned(event: NSignalBurned): void {
     event.params.tokensReceived,
   )
   curator.totalNameSignal = curator.totalNameSignal.minus(event.params.nSignalBurnt.toBigDecimal())
-  curator.totalNameSignalAverageCostBasis = curator.totalNameSignalAverageCostBasis.minus(diffACB)
+  curator.totalNameSignalAverageCostBasis = curator.totalNameSignalAverageCostBasis.minus(diffACBNameSignal)
   if (curator.totalNameSignal == BigDecimal.fromString('0')) {
     curator.totalAverageCostBasisPerNameSignal = BigDecimal.fromString('0')
   } else {
@@ -313,10 +347,36 @@ export function handleNSignalBurned(event: NSignalBurned): void {
     )
   }
 
-  if (isNameSignalBecomingInactive) {
+  // vSignal ACB
+  // update acb to reflect new name signal balance
+  let previousACBSignal = nameSignal.signalAverageCostBasis
+  nameSignal.signalAverageCostBasis = nameSignal.signal
+    .toBigDecimal()
+    .times(nameSignal.signalAverageCostBasisPerSignal)
+  let diffACBSignal = previousACBSignal.minus(nameSignal.signalAverageCostBasis)
+  if (nameSignal.signalAverageCostBasis == zeroBD) {
+    nameSignal.signalAverageCostBasisPerSignal = zeroBD
+  }
+  nameSignal.save()
+
+  // Update curator
+  curator.totalUnsignalledTokens = curator.totalUnsignalledTokens.plus(event.params.tokensReceived)
+  curator.totalSignal = curator.totalSignal.minus(event.params.vSignalBurnt.toBigDecimal())
+  curator.totalSignalAverageCostBasis = curator.totalSignalAverageCostBasis.minus(diffACBSignal)
+  if (curator.totalSignal == zeroBD) {
+    curator.totalAverageCostBasisPerSignal = zeroBD
+  } else {
+    curator.totalAverageCostBasisPerSignal = curator.totalSignalAverageCostBasis.div(
+      curator.totalSignal,
+    )
+  }
+
+
+  if(isNameSignalBecomingInactive) {
     curator.activeNameSignalCount = curator.activeNameSignalCount - 1
     curator.activeCombinedSignalCount = curator.activeCombinedSignalCount - 1
   }
+
   curator.save()
 
   // Create n signal tx
@@ -376,7 +436,16 @@ export function handleGRTWithdrawn(event: GRTWithdrawn): void {
   )
   nameSignal.withdrawnTokens = event.params.withdrawnGRT
   nameSignal.nameSignal = nameSignal.nameSignal.minus(event.params.nSignalBurnt)
+  // Resetting this one since we don't have the value to subtract, but it should be 0 anyways.
+  nameSignal.signal = BigInt.fromI32(0)
   nameSignal.lastNameSignalChange = event.block.timestamp.toI32()
+
+  // Reset everything to 0 since this empties the signal
+  nameSignal.nameSignalAverageCostBasis = BigDecimal.fromString('0')
+  nameSignal.nameSignalAverageCostBasisPerSignal = BigDecimal.fromString('0')
+  nameSignal.signalAverageCostBasis = BigDecimal.fromString('0')
+  nameSignal.signalAverageCostBasisPerSignal = BigDecimal.fromString('0')
+
   nameSignal.save()
 
   let curator = Curator.load(event.params.nameCurator.toHexString())

--- a/src/mappings/gns.ts
+++ b/src/mappings/gns.ts
@@ -202,7 +202,9 @@ export function handleNSignalMinted(event: NSignalMinted): void {
   subgraph.nameSignalAmount = subgraph.nameSignalAmount.plus(event.params.nSignalCreated)
   subgraph.signalAmount = subgraph.signalAmount.plus(event.params.vSignalCreated)
   subgraph.signalledTokens = subgraph.signalledTokens.plus(event.params.tokensDeposited)
-  subgraph.currentSignalledTokens = subgraph.currentSignalledTokens.plus(event.params.tokensDeposited)
+  subgraph.currentSignalledTokens = subgraph.currentSignalledTokens.plus(
+    event.params.tokensDeposited,
+  )
   subgraph.save()
 
   // Update the curator
@@ -218,16 +220,14 @@ export function handleNSignalMinted(event: NSignalMinted): void {
 
   // zero division protection
   if (curator.totalNameSignal != zeroBD) {
-    curator.totalAverageCostBasisPerNameSignal = curator.totalNameSignalAverageCostBasis.div(
-      curator.totalNameSignal,
-    )
+    curator.totalAverageCostBasisPerNameSignal = curator.totalNameSignalAverageCostBasis
+      .div(curator.totalNameSignal)
+      .truncate(18)
   }
 
   // vSignal
   // Might need to add the curation tax to this specific case
-  curator.totalSignalledTokens = curator.totalSignalledTokens.plus(
-    event.params.tokensDeposited,
-  )
+  curator.totalSignalledTokens = curator.totalSignalledTokens.plus(event.params.tokensDeposited)
   curator.totalSignalAverageCostBasis = curator.totalSignalAverageCostBasis.plus(
     event.params.tokensDeposited.toBigDecimal(),
   )
@@ -235,9 +235,9 @@ export function handleNSignalMinted(event: NSignalMinted): void {
 
   // zero division protection
   if (curator.totalSignal != zeroBD) {
-    curator.totalAverageCostBasisPerSignal = curator.totalSignalAverageCostBasis.div(
-      curator.totalSignal,
-    )
+    curator.totalAverageCostBasisPerSignal = curator.totalSignalAverageCostBasis
+      .div(curator.totalSignal)
+      .truncate(18)
   }
   curator.save()
 
@@ -247,19 +247,21 @@ export function handleNSignalMinted(event: NSignalMinted): void {
     nameSignal.nameSignal.isZero() && !event.params.nSignalCreated.isZero()
 
   nameSignal.nameSignal = nameSignal.nameSignal.plus(event.params.nSignalCreated)
-  nameSignal.signal = nameSignal.signal.plus(event.params.vSignalCreated)
+  nameSignal.signal = nameSignal.signal.plus(event.params.vSignalCreated.toBigDecimal())
   nameSignal.signalledTokens = nameSignal.signalledTokens.plus(event.params.tokensDeposited)
   nameSignal.lastNameSignalChange = event.block.timestamp.toI32()
   // nSignal
   nameSignal.nameSignalAverageCostBasis = nameSignal.nameSignalAverageCostBasis.plus(
     event.params.tokensDeposited.toBigDecimal(),
   )
+  nameSignal.averageCostBasis = nameSignal.nameSignalAverageCostBasis
 
   // zero division protection
   if (nameSignal.nameSignal.toBigDecimal() != zeroBD) {
-    nameSignal.nameSignalAverageCostBasisPerSignal = nameSignal.nameSignalAverageCostBasis.div(
-      nameSignal.nameSignal.toBigDecimal(),
-    )
+    nameSignal.nameSignalAverageCostBasisPerSignal = nameSignal.nameSignalAverageCostBasis
+      .div(nameSignal.nameSignal.toBigDecimal())
+      .truncate(18)
+    nameSignal.averageCostBasisPerSignal = nameSignal.nameSignalAverageCostBasisPerSignal
   }
 
   // vSignal
@@ -268,16 +270,16 @@ export function handleNSignalMinted(event: NSignalMinted): void {
   )
 
   // zero division protection
-  if (nameSignal.signal.toBigDecimal() != zeroBD) {
-    nameSignal.signalAverageCostBasisPerSignal = nameSignal.signalAverageCostBasis.div(
-      nameSignal.signal.toBigDecimal(),
-    )
+  if (nameSignal.signal != zeroBD) {
+    nameSignal.signalAverageCostBasisPerSignal = nameSignal.signalAverageCostBasis
+      .div(nameSignal.signal)
+      .truncate(18)
   }
   nameSignal.save()
 
   // reload curator, since it might update counters in another context and we don't want to overwrite it
   curator = Curator.load(curatorID) as Curator
-  if(isNameSignalBecomingActive) {
+  if (isNameSignalBecomingActive) {
     curator.activeNameSignalCount = curator.activeNameSignalCount + 1
     curator.activeCombinedSignalCount = curator.activeCombinedSignalCount + 1
   }
@@ -307,7 +309,9 @@ export function handleNSignalBurned(event: NSignalBurned): void {
   subgraph.nameSignalAmount = subgraph.nameSignalAmount.minus(event.params.nSignalBurnt)
   subgraph.signalAmount = subgraph.signalAmount.minus(event.params.vSignalBurnt)
   subgraph.unsignalledTokens = subgraph.unsignalledTokens.plus(event.params.tokensReceived)
-  subgraph.currentSignalledTokens = subgraph.currentSignalledTokens.minus(event.params.tokensReceived)
+  subgraph.currentSignalledTokens = subgraph.currentSignalledTokens.minus(
+    event.params.tokensReceived,
+  )
   subgraph.save()
 
   // update name signal
@@ -321,7 +325,7 @@ export function handleNSignalBurned(event: NSignalBurned): void {
     !nameSignal.nameSignal.isZero() && event.params.nSignalBurnt == nameSignal.nameSignal
 
   nameSignal.nameSignal = nameSignal.nameSignal.minus(event.params.nSignalBurnt)
-  nameSignal.signal = nameSignal.signal.minus(event.params.vSignalBurnt)
+  nameSignal.signal = nameSignal.signal.minus(event.params.vSignalBurnt.toBigDecimal())
   nameSignal.unsignalledTokens = nameSignal.unsignalledTokens.plus(event.params.tokensReceived)
   nameSignal.lastNameSignalChange = event.block.timestamp.toI32()
 
@@ -332,9 +336,11 @@ export function handleNSignalBurned(event: NSignalBurned): void {
     .toBigDecimal()
     .times(nameSignal.nameSignalAverageCostBasisPerSignal)
     .truncate(18)
+  nameSignal.averageCostBasis = nameSignal.nameSignalAverageCostBasis
   let diffACBNameSignal = previousACBNameSignal.minus(nameSignal.nameSignalAverageCostBasis)
   if (nameSignal.nameSignalAverageCostBasis == BigDecimal.fromString('0')) {
     nameSignal.nameSignalAverageCostBasisPerSignal = BigDecimal.fromString('0')
+    nameSignal.averageCostBasisPerSignal = BigDecimal.fromString('0')
   }
 
   // update curator
@@ -343,20 +349,21 @@ export function handleNSignalBurned(event: NSignalBurned): void {
     event.params.tokensReceived,
   )
   curator.totalNameSignal = curator.totalNameSignal.minus(event.params.nSignalBurnt.toBigDecimal())
-  curator.totalNameSignalAverageCostBasis = curator.totalNameSignalAverageCostBasis.minus(diffACBNameSignal)
+  curator.totalNameSignalAverageCostBasis = curator.totalNameSignalAverageCostBasis.minus(
+    diffACBNameSignal,
+  )
   if (curator.totalNameSignal == BigDecimal.fromString('0')) {
     curator.totalAverageCostBasisPerNameSignal = BigDecimal.fromString('0')
   } else {
-    curator.totalAverageCostBasisPerNameSignal = curator.totalNameSignalAverageCostBasis.div(
-      curator.totalNameSignal,
-    )
+    curator.totalAverageCostBasisPerNameSignal = curator.totalNameSignalAverageCostBasis
+      .div(curator.totalNameSignal)
+      .truncate(18)
   }
 
   // vSignal ACB
   // update acb to reflect new name signal balance
   let previousACBSignal = nameSignal.signalAverageCostBasis
   nameSignal.signalAverageCostBasis = nameSignal.signal
-    .toBigDecimal()
     .times(nameSignal.signalAverageCostBasisPerSignal)
     .truncate(18)
   let diffACBSignal = previousACBSignal.minus(nameSignal.signalAverageCostBasis)
@@ -372,13 +379,12 @@ export function handleNSignalBurned(event: NSignalBurned): void {
   if (curator.totalSignal == zeroBD) {
     curator.totalAverageCostBasisPerSignal = zeroBD
   } else {
-    curator.totalAverageCostBasisPerSignal = curator.totalSignalAverageCostBasis.div(
-      curator.totalSignal,
-    )
+    curator.totalAverageCostBasisPerSignal = curator.totalSignalAverageCostBasis
+      .div(curator.totalSignal)
+      .truncate(18)
   }
 
-
-  if(isNameSignalBecomingInactive) {
+  if (isNameSignalBecomingInactive) {
     curator.activeNameSignalCount = curator.activeNameSignalCount - 1
     curator.activeCombinedSignalCount = curator.activeCombinedSignalCount - 1
   }
@@ -415,27 +421,29 @@ export function handleNameSignalUpgrade(event: NameSignalUpgrade): void {
   subgraph.signalledTokens = subgraph.signalledTokens.plus(event.params.tokensSignalled)
   subgraph.save()
 
-  let signalRatio = subgraph.signalAmount / subgraph.nameSignalAmount
+  let signalRatio = subgraph.signalAmount.toBigDecimal() / subgraph.nameSignalAmount.toBigDecimal()
 
-  for(let i = 0; i < subgraph.nameSignalCount; i++) {
-    let relation = NameSignalSubgraphRelation.load(joinID([subgraphID, BigInt.fromI32(i).toString()]))
+  for (let i = 0; i < subgraph.nameSignalCount; i++) {
+    let relation = NameSignalSubgraphRelation.load(
+      joinID([subgraphID, BigInt.fromI32(i).toString()]),
+    )
     let nameSignal = NameSignal.load(relation.nameSignal)
-    if(!nameSignal.nameSignal.isZero()) {
+    if (!nameSignal.nameSignal.isZero()) {
       let curator = Curator.load(nameSignal.curator)
 
-      let oldSignal = nameSignal.signal;
-      nameSignal.signal = nameSignal.nameSignal * signalRatio
+      let oldSignal = nameSignal.signal
+      nameSignal.signal = nameSignal.nameSignal.toBigDecimal() * signalRatio
+      nameSignal.signal = nameSignal.signal.truncate(18)
 
       // zero division protection
-      if (nameSignal.signal.toBigDecimal() != zeroBD) {
-        nameSignal.signalAverageCostBasisPerSignal = nameSignal.signalAverageCostBasis.div(
-          nameSignal.signal.toBigDecimal(),
-        )
+      if (nameSignal.signal != zeroBD) {
+        nameSignal.signalAverageCostBasisPerSignal = nameSignal.signalAverageCostBasis
+          .div(nameSignal.signal)
+          .truncate(18)
       }
 
       let previousACBSignal = nameSignal.signalAverageCostBasis
       nameSignal.signalAverageCostBasis = nameSignal.signal
-        .toBigDecimal()
         .times(nameSignal.signalAverageCostBasisPerSignal)
         .truncate(18)
 
@@ -444,14 +452,14 @@ export function handleNameSignalUpgrade(event: NameSignalUpgrade): void {
         nameSignal.signalAverageCostBasisPerSignal = zeroBD
       }
 
-      curator.totalSignal = curator.totalSignal.minus(oldSignal.toBigDecimal()).plus(nameSignal.signal.toBigDecimal())
+      curator.totalSignal = curator.totalSignal.minus(oldSignal).plus(nameSignal.signal)
       curator.totalSignalAverageCostBasis = curator.totalSignalAverageCostBasis.minus(diffACBSignal)
       if (curator.totalSignal == zeroBD) {
         curator.totalAverageCostBasisPerSignal = zeroBD
       } else {
-        curator.totalAverageCostBasisPerSignal = curator.totalSignalAverageCostBasis.div(
-          curator.totalSignal,
-        )
+        curator.totalAverageCostBasisPerSignal = curator.totalSignalAverageCostBasis
+          .div(curator.totalSignal)
+          .truncate(18)
       }
       nameSignal.save()
       curator.save()
@@ -489,10 +497,12 @@ export function handleGRTWithdrawn(event: GRTWithdrawn): void {
   nameSignal.withdrawnTokens = event.params.withdrawnGRT
   nameSignal.nameSignal = nameSignal.nameSignal.minus(event.params.nSignalBurnt)
   // Resetting this one since we don't have the value to subtract, but it should be 0 anyways.
-  nameSignal.signal = BigInt.fromI32(0)
+  nameSignal.signal = BigDecimal.fromString('0')
   nameSignal.lastNameSignalChange = event.block.timestamp.toI32()
 
   // Reset everything to 0 since this empties the signal
+  nameSignal.averageCostBasis = BigDecimal.fromString('0')
+  nameSignal.averageCostBasisPerSignal = BigDecimal.fromString('0')
   nameSignal.nameSignalAverageCostBasis = BigDecimal.fromString('0')
   nameSignal.nameSignalAverageCostBasisPerSignal = BigDecimal.fromString('0')
   nameSignal.signalAverageCostBasis = BigDecimal.fromString('0')

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -41,6 +41,7 @@ export function createOrLoadSubgraph(
     subgraph.unsignalledTokens = BigInt.fromI32(0)
     subgraph.currentSignalledTokens = BigInt.fromI32(0)
     subgraph.nameSignalAmount = BigInt.fromI32(0)
+    subgraph.signalAmount = BigInt.fromI32(0)
     subgraph.reserveRatio = 0
     subgraph.withdrawableTokens = BigInt.fromI32(0)
     subgraph.withdrawnTokens = BigInt.fromI32(0)

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -301,9 +301,11 @@ export function createOrLoadNameSignal(
     nameSignal.unsignalledTokens = BigInt.fromI32(0)
     nameSignal.withdrawnTokens = BigInt.fromI32(0)
     nameSignal.nameSignal = BigInt.fromI32(0)
-    nameSignal.signal = BigInt.fromI32(0)
+    nameSignal.signal = BigDecimal.fromString('0')
     nameSignal.lastNameSignalChange = 0
     nameSignal.realizedRewards = BigInt.fromI32(0)
+    nameSignal.averageCostBasis = BigDecimal.fromString('0')
+    nameSignal.averageCostBasisPerSignal = BigDecimal.fromString('0')
     nameSignal.nameSignalAverageCostBasis = BigDecimal.fromString('0')
     nameSignal.nameSignalAverageCostBasisPerSignal = BigDecimal.fromString('0')
     nameSignal.signalAverageCostBasis = BigDecimal.fromString('0')

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -39,6 +39,7 @@ export function createOrLoadSubgraph(
 
     subgraph.signalledTokens = BigInt.fromI32(0)
     subgraph.unsignalledTokens = BigInt.fromI32(0)
+    subgraph.currentSignalledTokens = BigInt.fromI32(0)
     subgraph.nameSignalAmount = BigInt.fromI32(0)
     subgraph.reserveRatio = 0
     subgraph.withdrawableTokens = BigInt.fromI32(0)
@@ -297,10 +298,13 @@ export function createOrLoadNameSignal(
     nameSignal.unsignalledTokens = BigInt.fromI32(0)
     nameSignal.withdrawnTokens = BigInt.fromI32(0)
     nameSignal.nameSignal = BigInt.fromI32(0)
+    nameSignal.signal = BigInt.fromI32(0)
     nameSignal.lastNameSignalChange = 0
     nameSignal.realizedRewards = BigInt.fromI32(0)
-    nameSignal.averageCostBasis = BigDecimal.fromString('0')
-    nameSignal.averageCostBasisPerSignal = BigDecimal.fromString('0')
+    nameSignal.nameSignalAverageCostBasis = BigDecimal.fromString('0')
+    nameSignal.nameSignalAverageCostBasisPerSignal = BigDecimal.fromString('0')
+    nameSignal.signalAverageCostBasis = BigDecimal.fromString('0')
+    nameSignal.signalAverageCostBasisPerSignal = BigDecimal.fromString('0')
     nameSignal.save()
 
     let curatorEntity = Curator.load(curator)

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -17,6 +17,7 @@ import {
   Network,
   SubgraphCategory,
   SubgraphCategoryRelation,
+  NameSignalSubgraphRelation,
 } from '../types/schema'
 import { ENS } from '../types/GNS/ENS'
 import { Controller } from '../types/Controller/Controller'
@@ -45,6 +46,7 @@ export function createOrLoadSubgraph(
     subgraph.reserveRatio = 0
     subgraph.withdrawableTokens = BigInt.fromI32(0)
     subgraph.withdrawnTokens = BigInt.fromI32(0)
+    subgraph.nameSignalCount = 0
 
     subgraph.metadataHash = Bytes.fromI32(0) as Bytes
 
@@ -312,6 +314,15 @@ export function createOrLoadNameSignal(
     curatorEntity.nameSignalCount = curatorEntity.nameSignalCount + 1
     curatorEntity.combinedSignalCount = curatorEntity.combinedSignalCount + 1
     curatorEntity.save()
+
+    let subgraphEntity = Subgraph.load(subgraphID)
+    let relation = new NameSignalSubgraphRelation(joinID([subgraphID, BigInt.fromI32(subgraphEntity.nameSignalCount).toString()]))
+    subgraphEntity.nameSignalCount = subgraphEntity.nameSignalCount + 1;
+    subgraphEntity.save()
+
+    relation.subgraph = subgraphEntity.id;
+    relation.nameSignal = nameSignal.id;
+    relation.save()
   }
   return nameSignal as NameSignal
 }

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -68,6 +68,8 @@ dataSources:
           handler: handleSubgraphMetadataUpdated
         - event: NameSignalEnabled(indexed address,indexed uint256,indexed bytes32,uint32)
           handler: handleNameSignalEnabled
+        - event: NameSignalUpgrade(indexed address,indexed uint256,uint256,uint256,indexed bytes32)
+          handler: handleNameSignalUpgrade
         - event: NSignalMinted(indexed address,indexed uint256,indexed address,uint256,uint256,uint256)
           handler: handleNSignalMinted
         - event: NSignalBurned(indexed address,indexed uint256,indexed address,uint256,uint256,uint256)


### PR DESCRIPTION
* Added `signal` values to the `NameSignal` entity. This was done so that the `Curator` entity could then have an accurate depiction of the total average cost basis and total signal values.
* Added all related `averageCostBasis` fields for `signal` on the `NameSignal` entity.
* `totalSignalAverageCostBasis` and `totalSignal` on the `Curator` entity now correctly depicts signals independently of where they where actually signalled from (GNS or Curation contracts). `totalNameSignalAverageCostBasis` and `totalNameSignal` will still be valid and only track those amounts related only to the name signals (GNS).
* Fixed an issue where the `nameSignal` would be 0, but the average cost basis field still had a non-zero value.