### PR TITLE
Added active delegator count, as well as delegations count

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -155,8 +155,14 @@ type GraphNetwork @entity {
   indexerCount: Int!
   "Number of indexers that currently have some stake in the protocol"
   stakedIndexersCount: Int!
-  "Total delegators"
+  "Total amount of delegators historically"
   delegatorCount: Int!
+  "Total active delegators. Those that still have at least one active delegation."
+  activeDelegatorCount: Int!
+  "Total amount of delegations historically"
+  delegationCount: Int!
+  "Total active delegations. Those delegations that still have GRT staked towards an indexer"
+  activeDelegationCount: Int!
   "Total curators"
   curatorCount: Int!
   "Total subgraphs"
@@ -681,6 +687,11 @@ type Delegator @entity {
   createdAt: Int!
   "Total realized rewards on all delegated stakes. Realized rewards are added when undelegating and realizing a profit"
   totalRealizedRewards: BigDecimal!
+
+  "Total DelegatedStake entity count (Active and inactive)"
+  stakesCount: Int!
+  "Active DelegatedStake entity count. Active means it still GRT delegated"
+  activeStakesCount: Int!
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -690,7 +690,7 @@ type Delegator @entity {
 
   "Total DelegatedStake entity count (Active and inactive)"
   stakesCount: Int!
-  "Active DelegatedStake entity count. Active means it still GRT delegated"
+  "Active DelegatedStake entity count. Active means it still has GRT delegated"
   activeStakesCount: Int!
 }
 

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -157,6 +157,8 @@ export function createOrLoadDelegator(id: string, timestamp: BigInt): Delegator 
     delegator.totalUnstakedTokens = BigInt.fromI32(0)
     delegator.createdAt = timestamp.toI32()
     delegator.totalRealizedRewards = BigDecimal.fromString('0')
+    delegator.stakesCount = 0
+    delegator.activeStakesCount = 0
     delegator.save()
 
     let graphAccount = GraphAccount.load(id)
@@ -191,6 +193,14 @@ export function createOrLoadDelegatedStake(
     delegatedStake.createdAt = timestamp
 
     delegatedStake.save()
+
+    let delegatorEntity = Delegator.load(delegator)
+    delegatorEntity.stakesCount = delegatorEntity.stakesCount + 1;
+    delegatorEntity.save();
+
+    let graphNetwork = GraphNetwork.load('1')
+    graphNetwork.delegationCount = graphNetwork.delegationCount + 1
+    graphNetwork.save()
   }
   return delegatedStake as DelegatedStake
 }
@@ -453,6 +463,9 @@ export function createOrLoadGraphNetwork(
     graphNetwork.indexerCount = 0
     graphNetwork.stakedIndexersCount = 0
     graphNetwork.delegatorCount = 0
+    graphNetwork.activeDelegatorCount = 0
+    graphNetwork.delegationCount = 0
+    graphNetwork.activeDelegationCount = 0
     graphNetwork.curatorCount = 0
     graphNetwork.subgraphCount = 0
     graphNetwork.subgraphDeploymentCount = 0

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -218,19 +218,18 @@ export function handleStakeDelegated(event: StakeDelegated): void {
   // reload delegator to avoid edge case where we can overwrite stakesCount if stake is new
   delegator = Delegator.load(delegatorID) as Delegator
 
-  let isDelegatorBecomingActive = delegator.activeStakesCount == 0 && isStakeBecomingActive
-
   // upgrade graph network
   let graphNetwork = GraphNetwork.load('1')
   graphNetwork.totalDelegatedTokens = graphNetwork.totalDelegatedTokens.plus(event.params.tokens)
 
-  if(isDelegatorBecomingActive) {
-    graphNetwork.activeDelegatorCount = graphNetwork.activeDelegatorCount + 1
-  }
 
   if(isStakeBecomingActive) {
     graphNetwork.activeDelegationCount = graphNetwork.activeDelegationCount + 1
     delegator.activeStakesCount = delegator.activeStakesCount + 1
+    // Is delegator becoming active because of the stake becoming active?
+    if(delegator.activeStakesCount == 1) {
+      graphNetwork.activeDelegatorCount = graphNetwork.activeDelegatorCount + 1
+    }
   }
 
   graphNetwork.save()
@@ -278,19 +277,17 @@ export function handleStakeDelegatedLocked(event: StakeDelegatedLocked): void {
   delegator.totalUnstakedTokens = delegator.totalUnstakedTokens.plus(event.params.tokens)
   delegator.totalRealizedRewards = delegator.totalRealizedRewards.plus(realizedRewards)
 
-  let isDelegatorBecomingInactive = delegator.activeStakesCount == 1 && isStakeBecomingInactive
-
   // upgrade graph network
   let graphNetwork = GraphNetwork.load('1')
   graphNetwork.totalDelegatedTokens = graphNetwork.totalDelegatedTokens.minus(event.params.tokens)
 
-  if(isDelegatorBecomingInactive) {
-    graphNetwork.activeDelegatorCount = graphNetwork.activeDelegatorCount - 1
-  }
-
   if(isStakeBecomingInactive) {
     graphNetwork.activeDelegationCount = graphNetwork.activeDelegationCount - 1
     delegator.activeStakesCount = delegator.activeStakesCount - 1
+    // Is delegator becoming inactive because of the stake becoming inactive?
+    if(delegator.activeStakesCount == 0) {
+      graphNetwork.activeDelegatorCount = graphNetwork.activeDelegatorCount - 1
+    }
   }
 
   graphNetwork.save()


### PR DESCRIPTION
Added a few extra counters for active and total delegations (DelgatedStake), as well as active delegators

currently indexing in a dev subgraph: https://thegraph.com/explorer/subgraph/juanmardefago/dev-subgraph2?version=pending

Gonna be testing the resulting numbers afterwards, but should be accurate.

A delegator/delegation is considered inactive as soon as shares go to zero, and active when shares are higher than zero.