### PR TITLE
Adding signal/nameSignal count to Curator entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -775,6 +775,20 @@ type Curator @entity {
   totalSignalAverageCostBasis: BigDecimal!
   "totalSignalAverageCostBasis / totalSignal"
   totalAverageCostBasisPerSignal: BigDecimal!
+
+  # Curation counters
+  "Total amount of signals created by this user"
+  signalCount: Int!
+  "Amount of active signals for this user"
+  activeSignalCount: Int!
+  "Total amount of name signals created by this user"
+  nameSignalCount: Int!
+  "Amount of active name signals for this user"
+  activeNameSignalCount: Int!
+  "Total amount of name signals and signals created by this user. signalCount + nameSignalCount"
+  combinedSignalCount: Int!
+  "Amount of active name signals and signals for this user. signalCount + nameSignalCount"
+  activeCombinedSignalCount: Int!
 }
 
 """

--- a/src/mappings/gns.ts
+++ b/src/mappings/gns.ts
@@ -188,6 +188,9 @@ export function handleNSignalMinted(event: NSignalMinted): void {
     subgraphID,
     event.block.timestamp,
   )
+
+  let isNameSignalBecomingActive = nameSignal.nameSignal.isZero() && !event.params.nSignalCreated.isZero()
+
   nameSignal.nameSignal = nameSignal.nameSignal.plus(event.params.nSignalCreated)
   nameSignal.signalledTokens = nameSignal.signalledTokens.plus(event.params.tokensDeposited)
   nameSignal.lastNameSignalChange = event.block.timestamp.toI32()
@@ -219,6 +222,12 @@ export function handleNSignalMinted(event: NSignalMinted): void {
       curator.totalNameSignal,
     )
   }
+
+  if(isNameSignalBecomingActive) {
+    curator.activeNameSignalCount = curator.activeNameSignalCount + 1
+    curator.activeCombinedSignalCount = curator.activeCombinedSignalCount + 1
+  }
+
   curator.save()
 
   // Create n signal tx
@@ -253,6 +262,8 @@ export function handleNSignalBurned(event: NSignalBurned): void {
     event.block.timestamp,
   )
 
+  let isNameSignalBecomingInactive = !nameSignal.nameSignal.isZero() && event.params.nSignalBurnt == nameSignal.nameSignal
+
   nameSignal.nameSignal = nameSignal.nameSignal.minus(event.params.nSignalBurnt)
   nameSignal.unsignalledTokens = nameSignal.unsignalledTokens.plus(event.params.tokensReceived)
   nameSignal.lastNameSignalChange = event.block.timestamp.toI32()
@@ -281,6 +292,11 @@ export function handleNSignalBurned(event: NSignalBurned): void {
     curator.totalAverageCostBasisPerNameSignal = curator.totalNameSignalAverageCostBasis.div(
       curator.totalNameSignal,
     )
+  }
+
+  if(isNameSignalBecomingInactive) {
+    curator.activeNameSignalCount = curator.activeNameSignalCount - 1
+    curator.activeCombinedSignalCount = curator.activeCombinedSignalCount - 1
   }
   curator.save()
 

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -227,6 +227,13 @@ export function createOrLoadCurator(id: string, timestamp: BigInt): Curator {
     curator.totalSignalAverageCostBasis = BigDecimal.fromString('0')
     curator.totalSignal = BigDecimal.fromString('0')
     curator.totalAverageCostBasisPerSignal = BigDecimal.fromString('0')
+
+    curator.signalCount = 0
+    curator.activeSignalCount = 0
+    curator.nameSignalCount = 0
+    curator.activeNameSignalCount = 0
+    curator.combinedSignalCount = 0
+    curator.activeCombinedSignalCount = 0
     curator.save()
 
     let graphAccount = GraphAccount.load(id)
@@ -264,6 +271,11 @@ export function createOrLoadSignal(
     signal.lastUpdatedAt = timestamp
     signal.lastUpdatedAtBlock = blockNumber
     signal.save()
+
+    let curatorEntity = Curator.load(curator)
+    curatorEntity.signalCount = curatorEntity.signalCount + 1
+    curatorEntity.combinedSignalCount = curatorEntity.combinedSignalCount + 1
+    curatorEntity.save()
   }
   return signal as Signal
 }
@@ -289,6 +301,11 @@ export function createOrLoadNameSignal(
     nameSignal.averageCostBasis = BigDecimal.fromString('0')
     nameSignal.averageCostBasisPerSignal = BigDecimal.fromString('0')
     nameSignal.save()
+
+    let curatorEntity = Curator.load(curator)
+    curatorEntity.nameSignalCount = curatorEntity.nameSignalCount + 1
+    curatorEntity.combinedSignalCount = curatorEntity.combinedSignalCount + 1
+    curatorEntity.save()
   }
   return nameSignal as NameSignal
 }


### PR DESCRIPTION
This changes adds 6 counters to the curation entity:
* signalCount -> Total amount of signal entities created by the curator
* activeSignalCount -> Amount of active signal entities for this curator
* nameSignalCount -> Total amount of name signal entities created by the curator
* activeNameSignalCount -> Amount of active name signal entities for this curator
* combinedSignalCount -> Total amount of name signals and signals created by this user. signalCount + nameSignalCount
* activeCombinedSignalCount -> Amount of active name signals and signals for this user. signalCount + nameSignalCount