### PR TITLE
Added GraphAccount metadata update to tlws

### DIFF
--- a/src/mappings/metadataHelpers.template.ts
+++ b/src/mappings/metadataHelpers.template.ts
@@ -18,6 +18,19 @@ export function fetchGraphAccountMetadata(graphAccount: GraphAccount, ipfsHash: 
     }
     graphAccount.website = jsonToString(data.get('website'))
     graphAccount.save()
+
+    // Update all associated vesting contract addresses
+    let tlws = graphAccount.tokenLockWallets
+    for (let i = 0; i < tlws.length; i++) {
+      let tlw = GraphAccount.load(tlws[i])
+      tlw.codeRepository = graphAccount.codeRepository
+      tlw.description = graphAccount.description
+      tlw.image = graphAccount.image
+      tlw.displayName = graphAccount.displayName
+      tlw.isOrganization = graphAccount.isOrganization
+      tlw.website = graphAccount.website
+      tlw.save()
+    }
   }
   {{/ipfs}}
 }


### PR DESCRIPTION
Made sure to also update the metadata to all related TLWs when the beneficiary updates it. (this makes it so that both the name aswell as all related metadata information like image and website, is available for all TLWs related to a beneficiary address, directly from the subgraph)