### PR TITLE
Fix SubgraphVersion.version value setting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 build/
 node_modules/
 src/types
+generated/

--- a/config/addresses.template.ts
+++ b/config/addresses.template.ts
@@ -31,5 +31,5 @@ export let addresses: Addresses = {
   ensPublicResolver: '{{ensPublicResolver}}',
   blockNumber: '{{blockNumber}}',
   network: '{{network}}',
-  tokenLockManager: '{{tokenLockManager}}}'
+  tokenLockManager: '{{tokenLockManager}}}',
 }

--- a/config/mainnetAddressScript.ts
+++ b/config/mainnetAddressScript.ts
@@ -4,6 +4,7 @@ import * as networkAddresses from '@graphprotocol/contracts/addresses.json'
 import { Addresses } from './addresses.template'
 
 // mustache doesn't like numbered object keys
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let renameAddresses: any = networkAddresses
 renameAddresses['mainnet'] = networkAddresses['1']
 
@@ -21,7 +22,7 @@ export let addresses: Addresses = {
   ensPublicResolver: '{{mainnet.IPublicResolver}}',
   blockNumber: '',
   network: '',
-  tokenLockManager: ''
+  tokenLockManager: '',
 }
 
 const main = (): void => {
@@ -29,7 +30,7 @@ const main = (): void => {
     let output = JSON.parse(mustache.render(JSON.stringify(addresses), renameAddresses))
     output.blockNumber = '11440000' // Hardcoded a few thousand blocks before 1st contract deployed
     output.network = 'mainnet'
-    output.tokenLockManager = "0xFCf78AC094288D7200cfdB367A8CD07108dFa128"
+    output.tokenLockManager = '0xFCf78AC094288D7200cfdB367A8CD07108dFa128'
     fs.writeFileSync(__dirname + '/generatedAddresses.json', JSON.stringify(output, null, 2))
   } catch (e) {
     console.log(`Error saving artifacts: ${e.message}`)

--- a/config/rinkebyAddressScript.ts
+++ b/config/rinkebyAddressScript.ts
@@ -4,6 +4,7 @@ import * as networkAddresses from '@graphprotocol/contracts/addresses.json'
 import { Addresses } from './addresses.template'
 
 // mustache doesn't like numbered object keys
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let renameAddresses: any = networkAddresses
 renameAddresses['rinkeby'] = networkAddresses['4']
 

--- a/src/mappings/curation.ts
+++ b/src/mappings/curation.ts
@@ -1,10 +1,4 @@
-import {
-  Signalled,
-  Burned,
-  Collected,
-  Curation,
-  ParameterUpdated,
-} from '../types/Curation/Curation'
+import { Signalled, Burned, Curation, ParameterUpdated } from '../types/Curation/Curation'
 import {
   Curator,
   GraphNetwork,
@@ -12,7 +6,7 @@ import {
   SubgraphDeployment,
   SignalTransaction,
 } from '../types/schema'
-import { Address, BigInt } from '@graphprotocol/graph-ts'
+import { BigInt } from '@graphprotocol/graph-ts'
 
 import {
   createOrLoadSignal,

--- a/src/mappings/disputeManager.ts
+++ b/src/mappings/disputeManager.ts
@@ -1,12 +1,5 @@
 import { Address, BigDecimal, BigInt, ByteArray } from '@graphprotocol/graph-ts'
-import {
-  Indexer,
-  Allocation,
-  GraphNetwork,
-  SubgraphDeployment,
-  Dispute,
-  Attestation,
-} from '../types/schema'
+import { Allocation, GraphNetwork, Dispute, Attestation } from '../types/schema'
 import {
   ParameterUpdated,
   QueryDisputeCreated,

--- a/src/mappings/epochManager.ts
+++ b/src/mappings/epochManager.ts
@@ -1,7 +1,6 @@
 import { GraphNetwork } from '../types/schema'
 import { EpochRun, EpochLengthUpdate } from '../types/EpochManager/EpochManager'
 import { createOrLoadEpoch, createEpoch } from './helpers'
-import { log, BigInt } from '@graphprotocol/graph-ts'
 
 /**
  * @dev handleEpochRun

--- a/src/mappings/gns.ts
+++ b/src/mappings/gns.ts
@@ -1,4 +1,4 @@
-import { BigInt, BigDecimal, Bytes, json } from '@graphprotocol/graph-ts'
+import { BigInt, BigDecimal, Bytes } from '@graphprotocol/graph-ts'
 import {
   SubgraphPublished,
   SubgraphDeprecated,
@@ -197,15 +197,16 @@ export function handleSubgraphPublished(event: SubgraphPublished): void {
   let subgraphNumber = event.params.subgraphNumber.toString()
   let subgraphID = joinID([graphAccountID, subgraphNumber])
   let versionID: string
-  let versionNumber: number
+  let versionNumber: BigInt
 
   // Update subgraph
   let subgraph = createOrLoadSubgraph(subgraphID, event.params.graphAccount, event.block.timestamp)
   let oldVersionID = subgraph.currentVersion
 
-  versionID = joinID([subgraphID, subgraph.versionCount.toString()])
+  versionNumber = subgraph.versionCount
+  versionID = joinID([subgraphID, versionNumber.toString()])
   subgraph.currentVersion = versionID
-  subgraph.versionCount = subgraph.versionCount.plus(BigInt.fromI32(1))
+  subgraph.versionCount = versionNumber.plus(BigInt.fromI32(1))
 
   // Creates Graph Account, if needed
   createOrLoadGraphAccount(graphAccountID, event.params.graphAccount, event.block.timestamp)
@@ -220,7 +221,7 @@ export function handleSubgraphPublished(event: SubgraphPublished): void {
   let subgraphVersion = new SubgraphVersion(versionID)
   subgraphVersion.subgraph = subgraphID
   subgraphVersion.subgraphDeployment = subgraphDeploymentID
-  subgraphVersion.version = versionNumber as i32
+  subgraphVersion.version = versionNumber.toI32()
   subgraphVersion.createdAt = event.block.timestamp.toI32()
   let hexHash = changetype<Bytes>(addQm(event.params.versionMetadata))
   let base58Hash = hexHash.toBase58()
@@ -604,7 +605,7 @@ export function handleGRTWithdrawn(event: GRTWithdrawn): void {
 }
 
 /**
- * @dev handleParamterUpdated
+ * @dev handleParameterUpdated
  * - updates all parameters of GNS, depending on string passed. We then can
  *   call the contract directly to get the updated value
  */

--- a/src/mappings/gns.ts
+++ b/src/mappings/gns.ts
@@ -234,11 +234,7 @@ export function handleSubgraphPublished(event: SubgraphPublished): void {
     oldDeployment = SubgraphDeployment.load(oldVersion.subgraphDeployment)!
   }
   // create deployment - named subgraph relationship, and update the old one
-  updateCurrentDeploymentLinks(
-    oldDeployment,
-    deployment,
-    subgraph as Subgraph,
-  )
+  updateCurrentDeploymentLinks(oldDeployment, deployment, subgraph as Subgraph)
 }
 /**
  * @dev handleSubgraphDeprecated
@@ -259,17 +255,11 @@ export function handleSubgraphDeprecated(event: SubgraphDeprecated): void {
   graphNetwork.activeSubgraphCount = graphNetwork.activeSubgraphCount - 1
   graphNetwork.save()
 
-
   let version = SubgraphVersion.load(subgraph.currentVersion!)
   if (version != null) {
     let deployment = SubgraphDeployment.load(version.subgraphDeployment)
 
-    updateCurrentDeploymentLinks(
-      deployment,
-      null,
-      subgraph as Subgraph,
-      true
-    )
+    updateCurrentDeploymentLinks(deployment, null, subgraph as Subgraph, true)
   }
 }
 

--- a/src/mappings/graphToken.ts
+++ b/src/mappings/graphToken.ts
@@ -23,7 +23,7 @@ export function handleTransfer(event: Transfer): void {
 
   // no need to do any updates if it was a self transfer
   if (to == from) return
-  
+
   // Mint Transfer
   if (from.toHexString() == '0x0000000000000000000000000000000000000000') {
     graphNetwork.totalSupply = graphNetwork.totalSupply.plus(value)

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -65,9 +65,9 @@ export function createOrLoadSubgraphDeployment(
   subgraphID: string,
   timestamp: BigInt,
 ): SubgraphDeployment {
-  let graphNetwork = GraphNetwork.load('1')!
   let deployment = SubgraphDeployment.load(subgraphID)
   if (deployment == null) {
+    let graphNetwork = GraphNetwork.load('1')!
     let prefix = '1220'
     deployment = new SubgraphDeployment(subgraphID)
     deployment.ipfsHash = Bytes.fromHexString(prefix.concat(subgraphID.slice(2))).toBase58()
@@ -96,7 +96,6 @@ export function createOrLoadSubgraphDeployment(
     deployment.deprecatedSubgraphCount = 0
     deployment.save()
 
-    let graphNetwork = GraphNetwork.load('1')!
     graphNetwork.subgraphDeploymentCount = graphNetwork.subgraphDeploymentCount + 1
     graphNetwork.save()
   }
@@ -819,7 +818,7 @@ export function updateCurrentDeploymentLinks(
   if (oldDeployment != null) {
     if (!deprecated) {
       let oldRelationEntity = CurrentSubgraphDeploymentRelation.load(
-        subgraph.currentVersionRelationEntity!
+        subgraph.currentVersionRelationEntity!,
       )!
       oldRelationEntity.active = false
       oldRelationEntity.save()

--- a/src/mappings/rewardsManager.ts
+++ b/src/mappings/rewardsManager.ts
@@ -1,5 +1,5 @@
-import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
-import { Indexer, Allocation, GraphNetwork, Epoch, SubgraphDeployment } from '../types/schema'
+import { Address, BigInt } from '@graphprotocol/graph-ts'
+import { Indexer, Allocation, GraphNetwork, SubgraphDeployment } from '../types/schema'
 import {
   RewardsAssigned,
   ParameterUpdated,

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -1,4 +1,4 @@
-import { BigInt, Address, BigDecimal, Bytes, ipfs, log } from '@graphprotocol/graph-ts'
+import { BigInt, BigDecimal } from '@graphprotocol/graph-ts'
 import {
   StakeDeposited,
   StakeWithdrawn,
@@ -223,12 +223,11 @@ export function handleStakeDelegated(event: StakeDelegated): void {
   let graphNetwork = GraphNetwork.load('1')!
   graphNetwork.totalDelegatedTokens = graphNetwork.totalDelegatedTokens.plus(event.params.tokens)
 
-
-  if(isStakeBecomingActive) {
+  if (isStakeBecomingActive) {
     graphNetwork.activeDelegationCount = graphNetwork.activeDelegationCount + 1
     delegator.activeStakesCount = delegator.activeStakesCount + 1
     // Is delegator becoming active because of the stake becoming active?
-    if(delegator.activeStakesCount == 1) {
+    if (delegator.activeStakesCount == 1) {
       graphNetwork.activeDelegatorCount = graphNetwork.activeDelegatorCount + 1
     }
   }
@@ -258,7 +257,8 @@ export function handleStakeDelegatedLocked(event: StakeDelegatedLocked): void {
   let id = joinID([delegatorID, indexerID])
   let delegatedStake = DelegatedStake.load(id)!
 
-  let isStakeBecomingInactive = !delegatedStake.shareAmount.isZero() && delegatedStake.shareAmount == event.params.shares
+  let isStakeBecomingInactive =
+    !delegatedStake.shareAmount.isZero() && delegatedStake.shareAmount == event.params.shares
 
   delegatedStake.unstakedTokens = delegatedStake.unstakedTokens.plus(event.params.tokens)
   delegatedStake.shareAmount = delegatedStake.shareAmount.minus(event.params.shares)
@@ -282,11 +282,11 @@ export function handleStakeDelegatedLocked(event: StakeDelegatedLocked): void {
   let graphNetwork = GraphNetwork.load('1')!
   graphNetwork.totalDelegatedTokens = graphNetwork.totalDelegatedTokens.minus(event.params.tokens)
 
-  if(isStakeBecomingInactive) {
+  if (isStakeBecomingInactive) {
     graphNetwork.activeDelegationCount = graphNetwork.activeDelegationCount - 1
     delegator.activeStakesCount = delegator.activeStakesCount - 1
     // Is delegator becoming inactive because of the stake becoming inactive?
-    if(delegator.activeStakesCount == 0) {
+    if (delegator.activeStakesCount == 0) {
       graphNetwork.activeDelegatorCount = graphNetwork.activeDelegatorCount - 1
     }
   }
@@ -458,7 +458,7 @@ export function handleAllocationClosed(event: AllocationClosed): void {
   const indexerAccount = GraphAccount.load(indexer.account)!
   const closedByIndexer = event.params.sender == event.params.indexer
   const closedByOperator = indexerAccount.operators.includes(event.params.sender.toHexString())
-  
+
   if (!closedByIndexer && !closedByOperator) {
     indexer.forcedClosures = indexer.forcedClosures + 1
   }

--- a/src/mappings/tokenLockWallets/tokenLockWallet.ts
+++ b/src/mappings/tokenLockWallets/tokenLockWallet.ts
@@ -1,4 +1,4 @@
-import { BigInt, log } from '@graphprotocol/graph-ts'
+import { log } from '@graphprotocol/graph-ts'
 import {
   TokensReleased,
   TokensWithdrawn,

--- a/tests/factories/staking.ts
+++ b/tests/factories/staking.ts
@@ -1,6 +1,6 @@
-import { newMockEvent } from "matchstick-as/assembly/index"
-import { AllocationClosed, AllocationClosed__Params } from "../../src/types/Staking/Staking";
-import { Address, BigInt, ByteArray, Bytes, ethereum } from "@graphprotocol/graph-ts"
+import { newMockEvent } from 'matchstick-as/assembly/index'
+import { AllocationClosed } from '../../src/types/Staking/Staking'
+import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
 
 export function mockAllocationClosed(
   indexer: Address,
@@ -11,47 +11,33 @@ export function mockAllocationClosed(
   effectiveAllocation: BigInt,
   sender: Address,
   poi: Bytes,
-  isDelegator: boolean
+  isDelegator: boolean,
 ): AllocationClosed {
   const event = changetype<AllocationClosed>(newMockEvent())
 
   event.parameters = []
-  event.parameters.push(new ethereum.EventParam(
-    "indexer", 
-    ethereum.Value.fromAddress(indexer)
-  ))
-  event.parameters.push(new ethereum.EventParam(
-    "subgraphDeploymentID", 
-    ethereum.Value.fromBytes(subgraphDeploymentID)
-  ))
-  event.parameters.push(new ethereum.EventParam(
-    "epoch", 
-    ethereum.Value.fromUnsignedBigInt(epoch)
-    ))
-  event.parameters.push(new ethereum.EventParam(
-    "tokens", 
-    ethereum.Value.fromUnsignedBigInt(tokens)
-  ))
-  event.parameters.push(new ethereum.EventParam(
-    "allocationID", 
-    ethereum.Value.fromAddress(allocationID)
-  ))
-  event.parameters.push(new ethereum.EventParam(
-    "effectiveAllocation", 
-    ethereum.Value.fromUnsignedBigInt(effectiveAllocation)
-  ))
-  event.parameters.push(new ethereum.EventParam(
-    "sender", 
-    ethereum.Value.fromAddress(sender)
-  ))
-  event.parameters.push(new ethereum.EventParam(
-    "poi", 
-    ethereum.Value.fromBytes(poi)
-  ))
-  event.parameters.push(new ethereum.EventParam(
-    "isDelegator", 
-    ethereum.Value.fromBoolean(isDelegator)
-  ))
+  event.parameters.push(new ethereum.EventParam('indexer', ethereum.Value.fromAddress(indexer)))
+  event.parameters.push(
+    new ethereum.EventParam('subgraphDeploymentID', ethereum.Value.fromBytes(subgraphDeploymentID)),
+  )
+  event.parameters.push(new ethereum.EventParam('epoch', ethereum.Value.fromUnsignedBigInt(epoch)))
+  event.parameters.push(
+    new ethereum.EventParam('tokens', ethereum.Value.fromUnsignedBigInt(tokens)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam('allocationID', ethereum.Value.fromAddress(allocationID)),
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      'effectiveAllocation',
+      ethereum.Value.fromUnsignedBigInt(effectiveAllocation),
+    ),
+  )
+  event.parameters.push(new ethereum.EventParam('sender', ethereum.Value.fromAddress(sender)))
+  event.parameters.push(new ethereum.EventParam('poi', ethereum.Value.fromBytes(poi)))
+  event.parameters.push(
+    new ethereum.EventParam('isDelegator', ethereum.Value.fromBoolean(isDelegator)),
+  )
 
   return event
 }

--- a/tests/staking.test.ts
+++ b/tests/staking.test.ts
@@ -1,11 +1,14 @@
-import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
 
-import { clearStore, test, assert, createMockedFunction } from "matchstick-as/assembly/index";
+import { clearStore, test, assert, createMockedFunction } from 'matchstick-as/assembly/index'
 
-import {Allocation, Epoch, GraphAccount, GraphNetwork, Indexer} from '../src/types/schema'
-import {handleAllocationClosed} from '../src/mappings/staking'
-import {mockAllocationClosed} from './factories/staking'
-import { AllocationClosed, Staking__getAllocationResultValue0Struct } from "../src/types/Staking/Staking";
+import { Allocation, Epoch, GraphAccount, GraphNetwork, Indexer } from '../src/types/schema'
+import { handleAllocationClosed } from '../src/mappings/staking'
+import { mockAllocationClosed } from './factories/staking'
+import {
+  AllocationClosed,
+  Staking__getAllocationResultValue0Struct,
+} from '../src/types/Staking/Staking'
 
 const indexerID = '0x0000000000000000000000000000000000000001'
 const operatorID = '0x0000000000000000000000000000000000000002'
@@ -14,13 +17,13 @@ const allocationID = '0x0000000000000000000000000000000000000033'
 const deploymentID = '0x0000000000000000000000000000000000000044'
 const poi = '0xdBAfB0D805Df2A8017D87E1fb7C474DE7a301ceb'
 
-let event: AllocationClosed;
-let indexer: Indexer;
-let indexerAccount: GraphAccount;
-let allocation: Allocation;
-let operatorAccount: GraphAccount;
-let network: GraphNetwork;
-let epoch: Epoch;
+let event: AllocationClosed
+let indexer: Indexer
+let indexerAccount: GraphAccount
+let allocation: Allocation
+let operatorAccount: GraphAccount
+let network: GraphNetwork
+let epoch: Epoch
 
 function before(): void {
   // Set up test entities
@@ -39,8 +42,8 @@ function before(): void {
   operatorAccount.save()
 
   network = new GraphNetwork('1')
-  network.epochLength = 1000;
-  network.currentEpoch = 1;
+  network.epochLength = 1000
+  network.currentEpoch = 1
   network.save()
 
   epoch = new Epoch('1')
@@ -56,11 +59,11 @@ function before(): void {
     BigInt.fromI32(123123),
     changetype<Address>(Address.fromHexString(indexerID)),
     changetype<Bytes>(Bytes.fromHexString(poi)),
-    false
+    false,
   )
 
   // Mock contract calls
-  let stakingContractAddress = event.address;
+  let stakingContractAddress = event.address
   let returnTuple = new Staking__getAllocationResultValue0Struct(8)
   returnTuple[0] = ethereum.Value.fromAddress(changetype<Address>(Address.fromHexString(indexerID)))
   returnTuple[1] = ethereum.Value.fromBytes(changetype<Bytes>(Bytes.fromHexString(deploymentID)))
@@ -71,35 +74,47 @@ function before(): void {
   returnTuple[6] = ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1))
   returnTuple[7] = ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1))
 
-  createMockedFunction(stakingContractAddress, "getAllocation", "getAllocation(address):((address,bytes32,uint256,uint256,uint256,uint256,uint256,uint256))")
-      .withArgs([ethereum.Value.fromAddress(changetype<Address>(Address.fromHexString(allocationID)))])
-      .returns([ethereum.Value.fromTuple(returnTuple)]);
+  createMockedFunction(
+    stakingContractAddress,
+    'getAllocation',
+    'getAllocation(address):((address,bytes32,uint256,uint256,uint256,uint256,uint256,uint256))',
+  )
+    .withArgs([
+      ethereum.Value.fromAddress(changetype<Address>(Address.fromHexString(allocationID))),
+    ])
+    .returns([ethereum.Value.fromTuple(returnTuple)])
 }
 
 function after(): void {
   clearStore()
 }
 
-test('handleAllocationClosed doesnt increase forcedClosures if closed by indexer', () => { 
+test('handleAllocationClosed doesnt increase forcedClosures if closed by indexer', () => {
   before()
-  event.parameters[6].value = ethereum.Value.fromAddress(changetype<Address>(Address.fromHexString(indexerID)))
+  event.parameters[6].value = ethereum.Value.fromAddress(
+    changetype<Address>(Address.fromHexString(indexerID)),
+  )
   handleAllocationClosed(event)
-  assert.fieldEquals("Indexer", indexerID, "forcedClosures", "0");
+  assert.fieldEquals('Indexer', indexerID, 'forcedClosures', '0')
   after()
 })
 
-test('handleAllocationClosed doesnt increase forcedClosures if closed by operator', () => { 
+test('handleAllocationClosed doesnt increase forcedClosures if closed by operator', () => {
   before()
-  event.parameters[6].value = ethereum.Value.fromAddress(changetype<Address>(Address.fromHexString(operatorID)))
+  event.parameters[6].value = ethereum.Value.fromAddress(
+    changetype<Address>(Address.fromHexString(operatorID)),
+  )
   handleAllocationClosed(event)
-  assert.fieldEquals("Indexer", indexerID, "forcedClosures", "0");
+  assert.fieldEquals('Indexer', indexerID, 'forcedClosures', '0')
   after()
 })
 
-test('handleAllocationClosed increases forcedClosures by 1 if not closed by indexer or operator', () => { 
+test('handleAllocationClosed increases forcedClosures by 1 if not closed by indexer or operator', () => {
   before()
-  event.parameters[6].value = ethereum.Value.fromAddress(changetype<Address>(Address.fromHexString(otherAccountID)))
+  event.parameters[6].value = ethereum.Value.fromAddress(
+    changetype<Address>(Address.fromHexString(otherAccountID)),
+  )
   handleAllocationClosed(event)
-  assert.fieldEquals("Indexer", indexerID, "forcedClosures", "1");
+  assert.fieldEquals('Indexer', indexerID, 'forcedClosures', '1')
   after()
 })


### PR DESCRIPTION
I did some cleanup based on eslint and prettier suggestions, but the main thrust of this PR is to fix the version property value on `SubgraphVersion` entities (see src/mappings/gns.ts lines 200, 208, 209, and 224). Previously SubgraphVersion.version was always being set to 0. 

_Note: I'm currently testing the change locally._