### PR TITLE
Slightly more robust manifest parsing

### DIFF
--- a/src/mappings/metadataHelpers.template.ts
+++ b/src/mappings/metadataHelpers.template.ts
@@ -104,49 +104,41 @@ export function fetchSubgraphDeploymentManifest(deployment: SubgraphDeployment, 
     deployment.manifest = getManifestFromIPFS.toString()
 
     let manifest = deployment.manifest!
-    log.warning("BEFORE PARSING LOGIC FOR {}", [ipfsHash])
     // we take the right side of the split, since it's the one which will have the schema ipfs hash
     let schemaSplitTry = manifest.split('schema:\n', 2)
     if (schemaSplitTry.length == 2) {
       let schemaSplit = schemaSplitTry[1]
-      log.warning("After schema:\n split for {}", [ipfsHash])
 
       let schemaFileSplitTry = schemaSplit.split('/ipfs/', 2)
       if (schemaFileSplitTry.length == 2) {
         let schemaFileSplit = schemaFileSplitTry[1]
-        log.warning("After /ipfs/ split for {}", [ipfsHash])
 
         let schemaIpfsHashTry = schemaFileSplit.split('\n', 2)
         if (schemaIpfsHashTry.length == 2) {
           let schemaIpfsHash = schemaIpfsHashTry[0]
-          log.warning("After \n (schema) split for {}", [ipfsHash])
           deployment.schemaIpfsHash = schemaIpfsHash
-          log.warning("After getting schemaIpfsHash for {}", [ipfsHash])
 
           let getSchemaFromIPFS = ipfs.cat(schemaIpfsHash)
           if (getSchemaFromIPFS !== null) {
             deployment.schema = getSchemaFromIPFS.toString()
-            log.warning("Successful ipfs.cat for schema for {}", [ipfsHash])
           }
         } else {
-          log.warning("[MANIFEST PARSING FAIL] Deployment: {}, schema can't be parsed. Error: schemaIpfsHashTry.length isn't 2, actual length: {}", [ipfsHash, schemaIpfsHashTry.length.toString()])
+          log.warning("[MANIFEST PARSING FAIL] Deployment: {}, schema file hash can't be retrieved. Error: schemaIpfsHashTry.length isn't 2, actual length: {}", [ipfsHash, schemaIpfsHashTry.length.toString()])
         }
       } else {
-        log.warning("[MANIFEST PARSING FAIL] Deployment: {}, schema can't be parsed. Error: schemaFileSplitTry.length isn't 2, actual length: {}", [ipfsHash, schemaFileSplitTry.length.toString()])
+        log.warning("[MANIFEST PARSING FAIL] Deployment: {}, schema file hash can't be retrieved. Error: schemaFileSplitTry.length isn't 2, actual length: {}", [ipfsHash, schemaFileSplitTry.length.toString()])
       }
     } else {
-      log.warning("[MANIFEST PARSING FAIL] Deployment: {}, schema can't be parsed. Error: schemaSplitTry.length isn't 2, actual length: {}", [ipfsHash, schemaSplitTry.length.toString()])
+      log.warning("[MANIFEST PARSING FAIL] Deployment: {}, schema file hash can't be retrieved. Error: schemaSplitTry.length isn't 2, actual length: {}", [ipfsHash, schemaSplitTry.length.toString()])
     }
 
     // We get the first occurrence of `network` since subgraphs can only have data sources for the same network
     let networkSplitTry = manifest.split('network: ', 2)
     if (networkSplitTry.length == 2) {
       let networkSplit = networkSplitTry[1]
-      log.warning("After network: split for {}", [ipfsHash])
       let networkTry = networkSplit.split('\n', 2)
       if (networkTry.length == 2) {
         let network = networkTry[0]
-        log.warning("After \n (network) split for {}", [ipfsHash])
 
         createOrLoadNetwork(network)
         deployment.network = network
@@ -156,8 +148,6 @@ export function fetchSubgraphDeploymentManifest(deployment: SubgraphDeployment, 
     } else {
       log.warning("[MANIFEST PARSING FAIL] Deployment: {}, network can't be parsed. Error: networkSplitTry.length isn't 2, actual length: {}", [ipfsHash, networkSplitTry.length.toString()])
     }
-
-    log.warning("AFTER PARSING LOGIC FOR {}", [ipfsHash])
   }
   {{/ipfs}}
   return deployment as SubgraphDeployment

--- a/src/mappings/metadataHelpers.template.ts
+++ b/src/mappings/metadataHelpers.template.ts
@@ -104,24 +104,60 @@ export function fetchSubgraphDeploymentManifest(deployment: SubgraphDeployment, 
     deployment.manifest = getManifestFromIPFS.toString()
 
     let manifest = deployment.manifest!
-    /* Commenting out this, since it might be related to a weird error
+    log.warning("BEFORE PARSING LOGIC FOR {}", [ipfsHash])
     // we take the right side of the split, since it's the one which will have the schema ipfs hash
-    let schemaSplit = manifest.split('schema:\n', 2)[1]
-    let schemaFileSplit = schemaSplit.split('/ipfs/', 2)[1]
-    let schemaIpfsHash = schemaFileSplit.split('\n', 2)[0]
-    deployment.schemaIpfsHash = schemaIpfsHash
+    let schemaSplitTry = manifest.split('schema:\n', 2)
+    if (schemaSplitTry.length == 2) {
+      let schemaSplit = schemaSplitTry[1]
+      log.warning("After schema:\n split for {}", [ipfsHash])
 
-    let getSchemaFromIPFS = ipfs.cat(schemaIpfsHash)
-    if (getSchemaFromIPFS !== null) {
-      deployment.schema = getSchemaFromIPFS.toString()
+      let schemaFileSplitTry = schemaSplit.split('/ipfs/', 2)
+      if (schemaFileSplitTry.length == 2) {
+        let schemaFileSplit = schemaFileSplitTry[1]
+        log.warning("After /ipfs/ split for {}", [ipfsHash])
+
+        let schemaIpfsHashTry = schemaFileSplit.split('\n', 2)
+        if (schemaIpfsHashTry.length == 2) {
+          let schemaIpfsHash = schemaIpfsHashTry[0]
+          log.warning("After \n (schema) split for {}", [ipfsHash])
+          deployment.schemaIpfsHash = schemaIpfsHash
+          log.warning("After getting schemaIpfsHash for {}", [ipfsHash])
+
+          let getSchemaFromIPFS = ipfs.cat(schemaIpfsHash)
+          if (getSchemaFromIPFS !== null) {
+            deployment.schema = getSchemaFromIPFS.toString()
+            log.warning("Successful ipfs.cat for schema for {}", [ipfsHash])
+          }
+        } else {
+          log.warning("[MANIFEST PARSING FAIL] Deployment: {}, schema can't be parsed. Error: schemaIpfsHashTry.length isn't 2, actual length: {}", [ipfsHash, schemaIpfsHashTry.length.toString()])
+        }
+      } else {
+        log.warning("[MANIFEST PARSING FAIL] Deployment: {}, schema can't be parsed. Error: schemaFileSplitTry.length isn't 2, actual length: {}", [ipfsHash, schemaFileSplitTry.length.toString()])
+      }
+    } else {
+      log.warning("[MANIFEST PARSING FAIL] Deployment: {}, schema can't be parsed. Error: schemaSplitTry.length isn't 2, actual length: {}", [ipfsHash, schemaSplitTry.length.toString()])
     }
 
     // We get the first occurrence of `network` since subgraphs can only have data sources for the same network
-    let networkSplit = manifest.split('network: ', 2)[1]
-    let network = networkSplit.split('\n', 2)[0]
-    createOrLoadNetwork(network)
-    deployment.network = network
-    */
+    let networkSplitTry = manifest.split('network: ', 2)
+    if (networkSplitTry.length == 2) {
+      let networkSplit = networkSplitTry[1]
+      log.warning("After network: split for {}", [ipfsHash])
+      let networkTry = networkSplit.split('\n', 2)
+      if (networkTry.length == 2) {
+        let network = networkTry[0]
+        log.warning("After \n (network) split for {}", [ipfsHash])
+
+        createOrLoadNetwork(network)
+        deployment.network = network
+      } else {
+        log.warning("[MANIFEST PARSING FAIL] Deployment: {}, network can't be parsed. Error: networkTry.length isn't 2, actual length: {}", [ipfsHash, networkTry.length.toString()])
+      }
+    } else {
+      log.warning("[MANIFEST PARSING FAIL] Deployment: {}, network can't be parsed. Error: networkSplitTry.length isn't 2, actual length: {}", [ipfsHash, networkSplitTry.length.toString()])
+    }
+
+    log.warning("AFTER PARSING LOGIC FOR {}", [ipfsHash])
   }
   {{/ipfs}}
   return deployment as SubgraphDeployment


### PR DESCRIPTION
This change tries to improve the parsing code to make sure it doesn't fail if it can't find the basic expected format for a "valid" manifest. (I'm not entirely sure there's an official spec that would unambiguously define what is a "valid" manifest, but from what I could see being generated and the minimum requirements you need for it to be indexable, this should be as close as we have to a spec right now)