### PR TITLE
Assign creatorAddress in handleSubgraphPublishedV2

### DIFF
--- a/src/mappings/gns.ts
+++ b/src/mappings/gns.ts
@@ -760,6 +760,7 @@ export function handleSubgraphPublishedV2(event: SubgraphPublished1): void {
   subgraph.reserveRatio = event.params.reserveRatio.toI32()
   subgraph.migrated = true
   subgraph.initializing = true
+  subgraph.creatorAddress = changetype<Bytes>(event.transaction.from)
   subgraph.save()
 
   // Create subgraph deployment, if needed. Can happen if the deployment has never been staked on


### PR DESCRIPTION
The creatorAddress field has not been assigned for subgraphs created after 2022-02-23, as the graphAccount param is no longer associated with the SubgraphPublished event for v2.  This PR uses event.transaction.from instead.

Demonstration:
https://thegraph.com/hosted-service/subgraph/mnlesane/graph-network-mainnet
```{
  subgraphs(orderBy:createdAt, orderDirection:desc
  ) {
    id displayName creatorAddress
  }
}```