### PR TITLE
Update Pools for delayed collections

### DIFF
--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -398,18 +398,20 @@ export function handleAllocationCollected(event: AllocationCollected): void {
 
   // Update epoch
   let epoch = createOrLoadEpoch(allocation.closedAtBlockNumber? allocation.closedAtBlockNumber : event.block.number)
+  if (allocation.status == 'Closed'){
+    epoch.queryFeesCollected = epoch.queryFeesCollected.plus(allocation.queryFeesCollected)
+  }
   epoch.totalQueryFees = epoch.totalQueryFees.plus(event.params.tokens)
   epoch.taxedQueryFees = epoch.taxedQueryFees.plus(taxedFees)
-  epoch.queryFeesCollected = epoch.queryFeesCollected.plus(event.params.rebateFees)
   epoch.curatorQueryFees = epoch.curatorQueryFees.plus(event.params.curationFees)
   epoch.save()
 
   // update pool
-  let pool = createOrLoadPool(epoch.id? epoch.id : event.params.epoch)
+  let pool = createOrLoadPool(epoch.id)
   // ONLY if allocation is closed. Otherwise it gets collected into an allocation, and it will
   // get added to the pool where the allocation gets closed
   if (allocation.status == 'Closed') {
-    pool.totalQueryFees = pool.totalQueryFees.plus(event.params.rebateFees)
+    pool.totalQueryFees = pool.totalQueryFees.plus(allocation.queryFeesCollected)
   }
   // Curator rewards in pool is not stored in the contract, so we take the actual value of it
   // happening. Every time an allocation is collected, curator rewards get transferred into

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -397,7 +397,7 @@ export function handleAllocationCollected(event: AllocationCollected): void {
   let taxedFees = event.params.tokens.minus(event.params.rebateFees.plus(event.params.curationFees))
 
   // Update epoch
-  let epoch = createOrLoadEpoch(event.block.number)
+  let epoch = createOrLoadEpoch(allocation.closedAtBlockNumber? allocation.closedAtBlockNumber : event.block.number)
   epoch.totalQueryFees = epoch.totalQueryFees.plus(event.params.tokens)
   epoch.taxedQueryFees = epoch.taxedQueryFees.plus(taxedFees)
   epoch.queryFeesCollected = epoch.queryFeesCollected.plus(event.params.rebateFees)
@@ -405,7 +405,7 @@ export function handleAllocationCollected(event: AllocationCollected): void {
   epoch.save()
 
   // update pool
-  let pool = createOrLoadPool(event.params.epoch)
+  let pool = createOrLoadPool(epoch.id? epoch.id : event.params.epoch)
   // ONLY if allocation is closed. Otherwise it gets collected into an allocation, and it will
   // get added to the pool where the allocation gets closed
   if (allocation.status == 'Closed') {


### PR DESCRIPTION
Very minor change to detect delayed collections (collect in an epoch grater than the closedAtEpoch). 

Per the [Staking.sol](https://github.com/graphprotocol/contracts/blob/f1c5fe75c99a2170023d1fc0202b6513c9fe39a4/contracts/staking/Staking.sol#L1014) contract, query fees are added to the rebate pool in which the allocation was closed (not when the collect function is run).

Updated pool to attempt to use the closedAtEpoch if available, otherwise use the current epoch, but only update `epoch.queryFeesCollected` and `pool.totalQueryFees` when the allocation is closed so it can mirror what's seen in the rebate pool. 

Example: Epoch 634 has a total `fees` of `765540551752580194585` per the [Staking Contract](https://etherscan.io/address/0xf55041e37e12cd407ad00ce2910b8269b01263b9#readProxyContract#F28) yet the `pool.totalQueryFees` shows `918822211489531994645`. [query](https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-mainnet/graphql?query=query+Epoch634+%7B%0A++pool%28id%3A+%22634%22%29+%7B%0A++++id%0A++++totalQueryFees%0A++++closedAllocations%28where%3A+%7BclosedAtEpoch%3A+634%2C+queryFeesCollected_gt%3A+%220%22%7D%29+%7B%0A++++++closedAtEpoch%0A++++++id%0A++++++queryFeesCollected%0A++++++indexer+%7B%0A++++++++id%0A++++++%7D%0A++++%7D%0A++%7D%0A%7D)

Consideration: What happens if an allocation is collected on twice post allocation closure? This doesn't appear to be prevented in the contract and could result in double counting.
  