### PR TITLE
Make ethereumDIDRegistry configurable per chain

### DIFF
--- a/config/addresses.template.ts
+++ b/config/addresses.template.ts
@@ -18,6 +18,7 @@ export class Addresses {
   subgraphNFT: string
   l1GraphTokenGateway: string
   l2GraphTokenGateway: string
+  ethereumDIDRegistry: string
 }
 
 // AS compiler does not like const
@@ -40,4 +41,5 @@ export let addresses: Addresses = {
   subgraphNFT: '{{subgraphNFT}}',
   l1GraphTokenGateway: '{{l1GraphTokenGateway}}',
   l2GraphTokenGateway: '{{l2GraphTokenGateway}}',
+  ethereumDIDRegistry: '{{ethereumDIDRegistry}}',
 }

--- a/config/arbitrumGoerliAddressScript.ts
+++ b/config/arbitrumGoerliAddressScript.ts
@@ -27,6 +27,7 @@ export let addresses: Addresses = {
   subgraphNFT: '{{arbgor.SubgraphNFT.address}}',
   l1GraphTokenGateway: '',
   l2GraphTokenGateway: '{{arbgor.L2GraphTokenGateway.address}}',
+  ethereumDIDRegistry: '{{arbgor.IEthereumDIDRegistry.address}}',
 }
 
 const main = (): void => {

--- a/config/goerliAddressScript.ts
+++ b/config/goerliAddressScript.ts
@@ -27,6 +27,7 @@ export let addresses: Addresses = {
   subgraphNFT: '{{goerli.SubgraphNFT.address}}',
   l1GraphTokenGateway: '{{goerli.L1GraphTokenGateway.address}}',
   l2GraphTokenGateway: '',
+  ethereumDIDRegistry: '{{goerli.IEthereumDIDRegistry.address}}',
 }
 
 const main = (): void => {

--- a/config/mainnetAddressScript.ts
+++ b/config/mainnetAddressScript.ts
@@ -27,6 +27,7 @@ export let addresses: Addresses = {
   subgraphNFT: '{{mainnet.SubgraphNFT.address}}',
   l1GraphTokenGateway: '{{mainnet.L1GraphTokenGateway.address}}',
   l2GraphTokenGateway: '',
+  ethereumDIDRegistry: '{{mainnet.IEthereumDIDRegistry.address}}',
 }
 
 const main = (): void => {

--- a/config/mainnetArbitrumAddressScript.ts
+++ b/config/mainnetArbitrumAddressScript.ts
@@ -27,6 +27,7 @@ export let addresses: Addresses = {
   subgraphNFT: '{{arbitrum.SubgraphNFT.address}}',
   l1GraphTokenGateway: '',
   l2GraphTokenGateway: '{{arbitrum.L2GraphTokenGateway.address}}',
+  ethereumDIDRegistry: '{{arbitrum.IEthereumDIDRegistry.address}}',
 }
 
 const main = (): void => {

--- a/config/mainnetArbitrumAddressScript.ts
+++ b/config/mainnetArbitrumAddressScript.ts
@@ -38,6 +38,9 @@ const main = (): void => {
     output.bridgeBlockNumber = '42449749' // TBD
     output.tokenLockManager = '0xFCf78AC094288D7200cfdB367A8CD07108dFa128'
     output.useTokenLockManager = false
+    if(output.ethereumDIDRegistry == '') {
+      output.ethereumDIDRegistry = '0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B' // since the package doens't have it yet
+    }
     output.isL1 = false
     fs.writeFileSync(__dirname + '/generatedAddresses.json', JSON.stringify(output, null, 2))
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "graph test -v 0.2.0"
   },
   "devDependencies": {
-    "@graphprotocol/contracts": "2.1.0",
+    "@graphprotocol/contracts": "2.2.0",
     "@graphprotocol/graph-cli": "^0.25.1",
     "@graphprotocol/graph-ts": "^0.24.1",
     "@types/node": "^14.0.13",

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -270,7 +270,7 @@ dataSources:
     name: EthereumDIDRegistry
     network: {{network}}
     source:
-      address: "0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B"
+      address: "{{ethereumDIDRegistry}}"
       abi: EthereumDIDRegistry
       startBlock: {{blockNumber}}
     mapping:

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,10 +387,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@graphprotocol/contracts@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/contracts/-/contracts-2.1.0.tgz#c2e9131973af231e3f6f84ada31baebccc77ed48"
-  integrity sha512-SeymJCUxBp488K/KNi77EKvrkPT0t/7rERGp8zFkmf5KByerjihhE9Ty9oXJAU9RzbUpxsU0JkPBSmiw9/2DYQ==
+"@graphprotocol/contracts@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/contracts/-/contracts-2.2.0.tgz#19353a59237bd0769b73770da1fe15d4015ba9e3"
+  integrity sha512-jC//c6fYjKoUzAVsagUnrBe4rWdMv+FSxu0FMoyNB3wPVrI7qzly1LFB785wteEtHQzWnJPE6+EUMOlxXGMgsA==
   dependencies:
     console-table-printer "^2.11.1"
     ethers "^5.6.0"


### PR DESCRIPTION
In the past, all networks had the same contract address for the ethereumDIDRegistry that we were using, and thus, the address was hardcoded.
Now it's using the same address as stated in the contract package in each of the different chains, to accommodate for different deployments.