### PR TITLE
fix: off-by-one error on new environments

### DIFF
--- a/src/mappings/epochManager.ts
+++ b/src/mappings/epochManager.ts
@@ -26,7 +26,7 @@ export function handleEpochLengthUpdate(event: EpochLengthUpdate): void {
     // Will only ever be 0 on initialization in the contracts
     graphNetwork.epochLength = event.params.epochLength.toI32()
     graphNetwork.lastLengthUpdateBlock = (addresses.isL1 ? event.block.number : graphNetwork.currentL1BlockNumber!).toI32()
-    graphNetwork.currentEpoch = 0
+    graphNetwork.currentEpoch = event.params.epoch.toI32()
     graphNetwork.epochCount = 1
     graphNetwork.lastLengthUpdateEpoch = graphNetwork.currentEpoch
     graphNetwork.save()


### PR DESCRIPTION
Due to [this change](https://github.com/graphprotocol/contracts/commit/b352e49c4aabec381f412b0f9b5306d0638ac385), new environments are no longer initialized on epoch 0. To properly reflect the change (but also support older enviornments, i.e. mainnet) the change uses the defined epoch from the event triggered in the constructor as a separate case to properly initialize the first epoch.
Fix can be checked working on [mainnet](https://thegraph.com/hosted-service/subgraph/juanmardefago/dev-subgraph) and [goerli](https://thegraph.com/hosted-service/subgraph/juanmardefago/dev-subgraph2) dev subgraphs, comparing it to the EpochManager currentEpoch, and to prior versions of [mainnet](https://thegraph.com/hosted-service/subgraph/graphprotocol/graph-network-mainnet) and [goerli](https://thegraph.com/hosted-service/subgraph/graphprotocol/graph-network-goerli) (mainnet was ok, goerli was off-by-one as it was a newer environment)