### PR TITLE
Support exponential rebates upgrade

### DIFF
--- a/abis/IStakingStitched.json
+++ b/abis/IStakingStitched.json
@@ -1,0 +1,1994 @@
+[
+  {
+    "inputs": [],
+    "name": "channelDisputeEpochs",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "indexer", "type": "address" },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "subgraphDeploymentID",
+        "type": "bytes32"
+      },
+      { "indexed": false, "internalType": "uint256", "name": "epoch", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "tokens", "type": "uint256" },
+      { "indexed": true, "internalType": "address", "name": "allocationID", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "curationFees", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "rebateFees", "type": "uint256" }
+    ],
+    "name": "AllocationCollected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "indexer", "type": "address" },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "subgraphDeploymentID",
+        "type": "bytes32"
+      },
+      { "indexed": true, "internalType": "address", "name": "allocationID", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "epoch", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "forEpoch", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "tokens", "type": "uint256" },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "unclaimedAllocationsCount",
+        "type": "uint256"
+      },
+      { "indexed": false, "internalType": "uint256", "name": "delegationFees", "type": "uint256" }
+    ],
+    "name": "RebateClaimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "subgraphDeploymentID",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "allocationID",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "poi",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isPublic",
+        "type": "bool"
+      }
+    ],
+    "name": "AllocationClosed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "subgraphDeploymentID",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "allocationID",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "effectiveAllocation",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "poi",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isPublic",
+        "type": "bool"
+      }
+    ],
+    "name": "AllocationClosed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "subgraphDeploymentID",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "allocationID",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "metadata",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AllocationCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "assetHolder",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "AssetHolderUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "indexingRewardCut",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "queryFeeCut",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "cooldownBlocks",
+        "type": "uint32"
+      }
+    ],
+    "name": "DelegationParametersUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "extensionImpl",
+        "type": "address"
+      }
+    ],
+    "name": "ExtensionImplementationSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "assetHolder",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "subgraphDeploymentID",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "allocationID",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "protocolTax",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "curationFees",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queryFees",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queryRebates",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "delegationRewards",
+        "type": "uint256"
+      }
+    ],
+    "name": "RebateCollected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "SetOperator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "destination",
+        "type": "address"
+      }
+    ],
+    "name": "SetRewardsDestination",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "slasher",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "SlasherUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeDelegated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "until",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeDelegatedLocked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeDelegatedWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "until",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeLocked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      }
+    ],
+    "name": "StakeSlashed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeWithdrawn",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_subgraphDeploymentID",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokens",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_allocationID",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_metadata",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_proof",
+        "type": "bytes"
+      }
+    ],
+    "name": "allocate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_subgraphDeploymentID",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokens",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_allocationID",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_metadata",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_proof",
+        "type": "bytes"
+      }
+    ],
+    "name": "allocateFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_allocationID",
+        "type": "address"
+      }
+    ],
+    "name": "allocations",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "indexer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "subgraphDeploymentID",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokens",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "createdAtEpoch",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "closedAtEpoch",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "collectedFees",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "__DEPRECATED_effectiveAllocation",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "accRewardsPerAllocatedToken",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "distributedRebates",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IStakingData.Allocation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "alphaDenominator",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "alphaNumerator",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_maybeAssetHolder",
+        "type": "address"
+      }
+    ],
+    "name": "assetHolders",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_allocationID",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_poi",
+        "type": "bytes32"
+      }
+    ],
+    "name": "closeAllocation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokens",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_allocationID",
+        "type": "address"
+      }
+    ],
+    "name": "collect",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "controller",
+    "outputs": [
+      {
+        "internalType": "contract IController",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "curationPercentage",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "delegate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegationParametersCooldown",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      }
+    ],
+    "name": "delegationPools",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "cooldownBlocks",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "indexingRewardCut",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "queryFeeCut",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "updatedAtBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokens",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "shares",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IStakingExtension.DelegationPoolReturn",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegationRatio",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegationTaxPercentage",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegationUnbondingPeriod",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_allocationID",
+        "type": "address"
+      }
+    ],
+    "name": "getAllocation",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "indexer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "subgraphDeploymentID",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokens",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "createdAtEpoch",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "closedAtEpoch",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "collectedFees",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "__DEPRECATED_effectiveAllocation",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "accRewardsPerAllocatedToken",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "distributedRebates",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IStakingData.Allocation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_allocationID",
+        "type": "address"
+      }
+    ],
+    "name": "getAllocationState",
+    "outputs": [
+      {
+        "internalType": "enum IStakingBase.AllocationState",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_delegator",
+        "type": "address"
+      }
+    ],
+    "name": "getDelegation",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "shares",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokensLocked",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokensLockedUntil",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IStakingData.Delegation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      }
+    ],
+    "name": "getIndexerCapacity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      }
+    ],
+    "name": "getIndexerStakedTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_subgraphDeploymentID",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getSubgraphAllocatedTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "shares",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokensLocked",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokensLockedUntil",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IStakingData.Delegation",
+        "name": "_delegation",
+        "type": "tuple"
+      }
+    ],
+    "name": "getWithdraweableDelegatedTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      }
+    ],
+    "name": "hasStake",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_controller",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minimumIndexerStake",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_thawingPeriod",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_protocolPercentage",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_curationPercentage",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_maxAllocationEpochs",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_delegationUnbondingPeriod",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_delegationRatio",
+        "type": "uint32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "alphaNumerator",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "alphaDenominator",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "lambdaNumerator",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "lambdaDenominator",
+            "type": "uint32"
+          }
+        ],
+        "internalType": "struct IStakingData.RebatesParameters",
+        "name": "_rebatesParameters",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "_extensionImpl",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_allocationID",
+        "type": "address"
+      }
+    ],
+    "name": "isAllocation",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_delegator",
+        "type": "address"
+      }
+    ],
+    "name": "isDelegator",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      }
+    ],
+    "name": "isOperator",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lambdaDenominator",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lambdaNumerator",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxAllocationEpochs",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minimumIndexerStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "multicall",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "results",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_maybeOperator",
+        "type": "address"
+      }
+    ],
+    "name": "operatorAuth",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolPercentage",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      }
+    ],
+    "name": "rewardsDestination",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_assetHolder",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "setAssetHolder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_controller",
+        "type": "address"
+      }
+    ],
+    "name": "setController",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_counterpart",
+        "type": "address"
+      }
+    ],
+    "name": "setCounterpartStakingAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_percentage",
+        "type": "uint32"
+      }
+    ],
+    "name": "setCurationPercentage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_indexingRewardCut",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_queryFeeCut",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_cooldownBlocks",
+        "type": "uint32"
+      }
+    ],
+    "name": "setDelegationParameters",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_blocks",
+        "type": "uint32"
+      }
+    ],
+    "name": "setDelegationParametersCooldown",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_delegationRatio",
+        "type": "uint32"
+      }
+    ],
+    "name": "setDelegationRatio",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_percentage",
+        "type": "uint32"
+      }
+    ],
+    "name": "setDelegationTaxPercentage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_delegationUnbondingPeriod",
+        "type": "uint32"
+      }
+    ],
+    "name": "setDelegationUnbondingPeriod",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_extensionImpl",
+        "type": "address"
+      }
+    ],
+    "name": "setExtensionImpl",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_maxAllocationEpochs",
+        "type": "uint32"
+      }
+    ],
+    "name": "setMaxAllocationEpochs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minimumIndexerStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMinimumIndexerStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "setOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_percentage",
+        "type": "uint32"
+      }
+    ],
+    "name": "setProtocolPercentage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_alphaNumerator",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_alphaDenominator",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_lambdaNumerator",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_lambdaDenominator",
+        "type": "uint32"
+      }
+    ],
+    "name": "setRebateParameters",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_destination",
+        "type": "address"
+      }
+    ],
+    "name": "setRewardsDestination",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_slasher",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "setSlasher",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_thawingPeriod",
+        "type": "uint32"
+      }
+    ],
+    "name": "setThawingPeriod",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokens",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_reward",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_beneficiary",
+        "type": "address"
+      }
+    ],
+    "name": "slash",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_maybeSlasher",
+        "type": "address"
+      }
+    ],
+    "name": "slashers",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      }
+    ],
+    "name": "stakes",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "tokensStaked",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokensAllocated",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokensLocked",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokensLockedUntil",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Stakes.Indexer",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_subgraphDeploymentId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "subgraphAllocations",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "syncAllContracts",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "thawingPeriod",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "undelegate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "unstake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexer",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_newIndexer",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawDelegated",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/IStakingStitched.json
+++ b/abis/IStakingStitched.json
@@ -1053,6 +1053,67 @@
         "type": "address"
       }
     ],
+    "name": "getAllocation",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "indexer",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "subgraphDeploymentID",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokens",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "createdAtEpoch",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "closedAtEpoch",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "collectedFees",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "effectiveAllocation",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "accRewardsPerAllocatedToken",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IStakingData.Allocation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_allocationID",
+        "type": "address"
+      }
+    ],
     "name": "getAllocationState",
     "outputs": [
       {

--- a/abis/StakingExtensionStitched.json
+++ b/abis/StakingExtensionStitched.json
@@ -1,0 +1,464 @@
+[
+  {
+    "inputs": [],
+    "name": "channelDisputeEpochs",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "nameHash", "type": "bytes32" },
+      { "indexed": false, "internalType": "address", "name": "contractAddress", "type": "address" }
+    ],
+    "name": "ContractSynced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "string", "name": "param", "type": "string" }],
+    "name": "ParameterUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "controller", "type": "address" }
+    ],
+    "name": "SetController",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "caller", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "slasher", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "allowed", "type": "bool" }
+    ],
+    "name": "SlasherUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "indexer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "delegator", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "tokens", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "shares", "type": "uint256" }
+    ],
+    "name": "StakeDelegated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "indexer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "delegator", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "tokens", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "shares", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "until", "type": "uint256" }
+    ],
+    "name": "StakeDelegatedLocked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "indexer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "delegator", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "tokens", "type": "uint256" }
+    ],
+    "name": "StakeDelegatedWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "indexer", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "tokens", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "reward", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "beneficiary", "type": "address" }
+    ],
+    "name": "StakeSlashed",
+    "type": "event"
+  },
+  {
+    "inputs": [{ "internalType": "contract IGraphProxy", "name": "_proxy", "type": "address" }],
+    "name": "acceptProxy",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "contract IGraphProxy", "name": "_proxy", "type": "address" },
+      { "internalType": "bytes", "name": "_data", "type": "bytes" }
+    ],
+    "name": "acceptProxyAndCall",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_allocationID", "type": "address" }],
+    "name": "allocations",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "indexer", "type": "address" },
+          { "internalType": "bytes32", "name": "subgraphDeploymentID", "type": "bytes32" },
+          { "internalType": "uint256", "name": "tokens", "type": "uint256" },
+          { "internalType": "uint256", "name": "createdAtEpoch", "type": "uint256" },
+          { "internalType": "uint256", "name": "closedAtEpoch", "type": "uint256" },
+          { "internalType": "uint256", "name": "collectedFees", "type": "uint256" },
+          {
+            "internalType": "uint256",
+            "name": "__DEPRECATED_effectiveAllocation",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "accRewardsPerAllocatedToken", "type": "uint256" },
+          { "internalType": "uint256", "name": "distributedRebates", "type": "uint256" }
+        ],
+        "internalType": "struct IStakingData.Allocation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "alphaDenominator",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "alphaNumerator",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_maybeAssetHolder", "type": "address" }],
+    "name": "assetHolders",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "controller",
+    "outputs": [{ "internalType": "contract IController", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "curationPercentage",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_indexer", "type": "address" },
+      { "internalType": "uint256", "name": "_tokens", "type": "uint256" }
+    ],
+    "name": "delegate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegationParametersCooldown",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_indexer", "type": "address" }],
+    "name": "delegationPools",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "uint32", "name": "cooldownBlocks", "type": "uint32" },
+          { "internalType": "uint32", "name": "indexingRewardCut", "type": "uint32" },
+          { "internalType": "uint32", "name": "queryFeeCut", "type": "uint32" },
+          { "internalType": "uint256", "name": "updatedAtBlock", "type": "uint256" },
+          { "internalType": "uint256", "name": "tokens", "type": "uint256" },
+          { "internalType": "uint256", "name": "shares", "type": "uint256" }
+        ],
+        "internalType": "struct IStakingExtension.DelegationPoolReturn",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegationRatio",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegationTaxPercentage",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegationUnbondingPeriod",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_indexer", "type": "address" },
+      { "internalType": "address", "name": "_delegator", "type": "address" }
+    ],
+    "name": "getDelegation",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "shares", "type": "uint256" },
+          { "internalType": "uint256", "name": "tokensLocked", "type": "uint256" },
+          { "internalType": "uint256", "name": "tokensLockedUntil", "type": "uint256" }
+        ],
+        "internalType": "struct IStakingData.Delegation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "shares", "type": "uint256" },
+          { "internalType": "uint256", "name": "tokensLocked", "type": "uint256" },
+          { "internalType": "uint256", "name": "tokensLockedUntil", "type": "uint256" }
+        ],
+        "internalType": "struct IStakingData.Delegation",
+        "name": "_delegation",
+        "type": "tuple"
+      }
+    ],
+    "name": "getWithdraweableDelegatedTokens",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "_delegationUnbondingPeriod", "type": "uint32" },
+      { "internalType": "uint32", "name": "_cooldownBlocks", "type": "uint32" },
+      { "internalType": "uint32", "name": "_delegationRatio", "type": "uint32" },
+      { "internalType": "uint32", "name": "_delegationTaxPercentage", "type": "uint32" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_indexer", "type": "address" },
+      { "internalType": "address", "name": "_delegator", "type": "address" }
+    ],
+    "name": "isDelegator",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lambdaDenominator",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lambdaNumerator",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxAllocationEpochs",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minimumIndexerStake",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_indexer", "type": "address" },
+      { "internalType": "address", "name": "_maybeOperator", "type": "address" }
+    ],
+    "name": "operatorAuth",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolPercentage",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_indexer", "type": "address" }],
+    "name": "rewardsDestination",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_controller", "type": "address" }],
+    "name": "setController",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint32", "name": "_blocks", "type": "uint32" }],
+    "name": "setDelegationParametersCooldown",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint32", "name": "_delegationRatio", "type": "uint32" }],
+    "name": "setDelegationRatio",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint32", "name": "_percentage", "type": "uint32" }],
+    "name": "setDelegationTaxPercentage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint32", "name": "_delegationUnbondingPeriod", "type": "uint32" }
+    ],
+    "name": "setDelegationUnbondingPeriod",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_slasher", "type": "address" },
+      { "internalType": "bool", "name": "_allowed", "type": "bool" }
+    ],
+    "name": "setSlasher",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_indexer", "type": "address" },
+      { "internalType": "uint256", "name": "_tokens", "type": "uint256" },
+      { "internalType": "uint256", "name": "_reward", "type": "uint256" },
+      { "internalType": "address", "name": "_beneficiary", "type": "address" }
+    ],
+    "name": "slash",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_maybeSlasher", "type": "address" }],
+    "name": "slashers",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_indexer", "type": "address" }],
+    "name": "stakes",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "tokensStaked", "type": "uint256" },
+          { "internalType": "uint256", "name": "tokensAllocated", "type": "uint256" },
+          { "internalType": "uint256", "name": "tokensLocked", "type": "uint256" },
+          { "internalType": "uint256", "name": "tokensLockedUntil", "type": "uint256" }
+        ],
+        "internalType": "struct Stakes.Indexer",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "_subgraphDeploymentId", "type": "bytes32" }],
+    "name": "subgraphAllocations",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "syncAllContracts",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "thawingPeriod",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_indexer", "type": "address" },
+      { "internalType": "uint256", "name": "_shares", "type": "uint256" }
+    ],
+    "name": "undelegate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_indexer", "type": "address" },
+      { "internalType": "address", "name": "_newIndexer", "type": "address" }
+    ],
+    "name": "withdrawDelegated",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "graph test -v 0.5.2"
   },
   "devDependencies": {
-    "@graphprotocol/contracts": "5.2.0",
+    "@graphprotocol/contracts": "^5.2.1",
     "@graphprotocol/graph-cli": "^0.49.0",
     "@graphprotocol/graph-ts": "^0.29.1",
     "@types/node": "^14.0.13",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "graph test -v 0.5.2"
   },
   "devDependencies": {
-    "@graphprotocol/contracts": "5.0.0",
+    "@graphprotocol/contracts": "5.2.0",
     "@graphprotocol/graph-cli": "^0.49.0",
     "@graphprotocol/graph-ts": "^0.29.1",
     "@types/node": "^14.0.13",

--- a/schema.graphql
+++ b/schema.graphql
@@ -46,7 +46,7 @@ type GraphNetwork @entity {
   protocolFeePercentage: Int!
   "Ratio of max staked delegation tokens to indexers stake that earns rewards"
   delegationRatio: Int!
-  "Epochs to wait before fees can be claimed in rebate pool"
+  "[DEPRECATED] Epochs to wait before fees can be claimed in rebate pool"
   channelDisputeEpochs: Int!
   "Epochs to wait before delegators can settle"
   maxAllocationEpochs: Int!
@@ -60,8 +60,12 @@ type GraphNetwork @entity {
   slashers: [Bytes!]
   "Time in epochs a delegator needs to wait to withdraw delegated stake"
   delegationUnbondingPeriod: Int!
-  "Alpha in the cobbs douglas formula"
+  "[DEPRECATED] Alpha in the cobbs douglas formula"
   rebateRatio: BigDecimal!
+  "Alpha in the exponential formula"
+  rebateAlpha: BigDecimal!
+  "Lambda in the exponential formula"
+  rebateLambda: BigDecimal!
   "Tax that delegators pay to deposit. In Parts per million"
   delegationTaxPercentage: Int!
   "Asset holder for the protocol"
@@ -655,7 +659,7 @@ type Indexer @entity {
   totalAllocationCount: BigInt!
   "Total query fees collected. Includes the portion given to delegators"
   queryFeesCollected: BigInt!
-  "Query fee rebate amount claimed from the protocol through cobbs douglas. Does not include portion given to delegators"
+  "Query fee rebate amount claimed from the protocol through rebates mechanism. Does not include portion given to delegators"
   queryFeeRebates: BigInt!
   "Total indexing rewards earned by this indexer from inflation. Including delegation rewards"
   rewardsEarned: BigInt!
@@ -751,7 +755,7 @@ type Allocation @entity {
   subgraphDeployment: SubgraphDeployment!
   "Tokens allocation in this allocation"
   allocatedTokens: BigInt!
-  "Effective allocation that is realized upon closing"
+  "[DEPRECATED] Effective allocation that is realized upon closing"
   effectiveAllocation: BigInt!
   "Epoch this allocation was created"
   createdAtEpoch: Int!
@@ -769,6 +773,8 @@ type Allocation @entity {
   queryFeesCollected: BigInt!
   "Query fee rebate amount claimed from the protocol through cobbs douglas. Does not include portion given to delegators"
   queryFeeRebates: BigInt!
+  "Query fee rebates collected from the protocol. Can differ from queryFeeRebates if multiple vouchers per allocation are allowed."
+  distributedRebates: BigInt!
   "Curator rewards deposited to the curating bonding curve"
   curatorRewards: BigInt!
   "Indexing rewards earned by this allocation. Includes delegator and indexer rewards"
@@ -777,7 +783,7 @@ type Allocation @entity {
   indexingIndexerRewards: BigInt!
   "Indexing rewards earned by this allocation by delegators"
   indexingDelegatorRewards: BigInt!
-  "Pool in which this allocation was closed"
+  "[DEPRECATED] Pool in which this allocation was closed"
   poolClosedIn: Pool
   "Fees paid out to delegators"
   delegationFees: BigInt!
@@ -812,12 +818,12 @@ enum AllocationStatus {
   Null # == indexer == address(0)
   Active # == not Null && tokens > 0 #
   Closed # == Active && closedAtEpoch != 0. Still can collect, while you are waiting to be finalized. a.k.a settling
-  Finalized # == Closing && closedAtEpoch + channelDisputeEpochs > now(). Note, the subgraph has no way to return this value. it is implied
-  Claimed # == not Null && tokens == 0 - i.e. finalized, and all tokens withdrawn
+  Finalized # == [DEPRECATED] Closing && closedAtEpoch + channelDisputeEpochs > now(). Note, the subgraph has no way to return this value. it is implied
+  Claimed # == [DEPRECATED] not Null && tokens == 0 - i.e. finalized, and all tokens withdrawn
 }
 
 """
-Global pool of query fees for closed state channels. Each Epoch has a single pool,
+[DEPRECATED] Global pool of query fees for closed state channels. Each Epoch has a single pool,
 hence why they share the same IDs.
 """
 type Pool @entity {
@@ -1184,11 +1190,11 @@ type Epoch @entity {
   totalQueryFees: BigInt!
   "Amount of query fees generated that were burnt by the 1% protocol tax during this epoch"
   taxedQueryFees: BigInt!
-  "Amount of query fees generated that are going to the rebate pool for indexers during this epoch"
+  "Amount of query fees generated for indexers during this epoch"
   queryFeesCollected: BigInt!
   "Amount of query fees generated that are going to curators during this epoch"
   curatorQueryFees: BigInt!
-  "Rebate amount claimed from the protocol through cobbs douglas during this epoch (Doesn't correlate to the queryFeesCollected for this epoch since there's a 7 day period before claiming)"
+  "Rebate amount claimed from the protocol through rebates mechanism during this epoch"
   queryFeeRebates: BigInt!
   "Total indexing rewards earned in this epoch. Includes both delegator and indexer rewards"
   totalRewards: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -113,7 +113,7 @@ type GraphNetwork @entity {
   "Total protocol taxes applied to the query fees"
   totalTaxedQueryFees: BigInt!
   # It is hard to separate the unclaimed and rebates lost
-  "Total unclaimed rebates. Includes unclaimed rebates, and rebates lost in cobbs douglas "
+  "Total unclaimed rebates. Includes unclaimed rebates, and rebates lost in rebates mechanism "
   totalUnclaimedQueryFeeRebates: BigInt!
 
   # Indexing rewards globals
@@ -543,7 +543,7 @@ type SubgraphDeployment @entity {
   indexingDelegatorRewardAmount: BigInt!
   "Total query fees earned by this Subgraph Deployment, without curator query fees"
   queryFeesAmount: BigInt!
-  "Total query fee rebates earned from the protocol, through the cobbs douglas formula. Does not include delegation fees"
+  "Total query fee rebates earned from the protocol, through the rebates formula. Does not include delegation fees"
   queryFeeRebates: BigInt!
   "Total curator rewards from fees"
   curatorFeeRewards: BigInt!
@@ -771,7 +771,7 @@ type Allocation @entity {
   closedAtBlockNumber: Int
   "Fees this allocation collected from query fees upon closing. Excludes curator reward and protocol tax"
   queryFeesCollected: BigInt!
-  "Query fee rebate amount claimed from the protocol through cobbs douglas. Does not include portion given to delegators"
+  "Query fee rebate amount claimed from the protocol through rebates mechanism. Does not include portion given to delegators"
   queryFeeRebates: BigInt!
   "Query fee rebates collected from the protocol. Can differ from queryFeeRebates if multiple vouchers per allocation are allowed."
   distributedRebates: BigInt!
@@ -833,7 +833,7 @@ type Pool @entity {
   allocation: BigInt!
   "Total query fees collected in this epoch"
   totalQueryFees: BigInt!
-  "Total query fees claimed in this epoch. Can be smaller than totalFees because of cobbs douglas function "
+  "Total query fees claimed in this epoch. Can be smaller than totalFees because of rebates function "
   claimedFees: BigInt!
   "Total rewards from query fees deposited to all curator bonding curves during the epoch"
   curatorRewards: BigInt!

--- a/src/mappings/helpers/helpers.ts
+++ b/src/mappings/helpers/helpers.ts
@@ -500,6 +500,8 @@ export function createOrLoadGraphNetwork(
     graphNetwork.delegationUnbondingPeriod = 0
     graphNetwork.delegationTaxPercentage = 0
     graphNetwork.rebateRatio = BigDecimal.fromString('0')
+    graphNetwork.rebateAlpha = BigDecimal.fromString('0')
+    graphNetwork.rebateLambda = BigDecimal.fromString('0')
 
     graphNetwork.totalTokensStakedTransferredToL2 = BigInt.fromI32(0)
     graphNetwork.totalDelegatedTokensTransferredToL2 = BigInt.fromI32(0)

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -586,7 +586,7 @@ export function handleAllocationClosedCobbDouglas(event: AllocationClosed1): voi
   // We must call the contract directly to see how many fees are getting closed in this
   // allocation. The event does not emit this information
   let staking = Staking.bind(event.address)
-  let contractAlloc = staking.getAllocation(event.params.allocationID)
+  let contractAlloc = staking.getAllocation1(event.params.allocationID)
   pool.totalQueryFees = pool.totalQueryFees.plus(contractAlloc.collectedFees)
   pool.save()
 

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -358,6 +358,7 @@ export function handleAllocationCreated(event: AllocationCreated): void {
   ).toI32()
   allocation.queryFeesCollected = BigInt.fromI32(0)
   allocation.queryFeeRebates = BigInt.fromI32(0)
+  allocation.distributedRebates = BigInt.fromI32(0)
   allocation.curatorRewards = BigInt.fromI32(0)
   allocation.indexingRewards = BigInt.fromI32(0)
   allocation.indexingIndexerRewards = BigInt.fromI32(0)

--- a/src/mappings/staking.ts
+++ b/src/mappings/staking.ts
@@ -6,6 +6,7 @@ import {
   StakeSlashed,
   AllocationCreated,
   AllocationClosed,
+  AllocationClosed1, // This is the event pre exponential rebates
   RebateClaimed,
   Staking,
   SetOperator,
@@ -13,6 +14,7 @@ import {
   StakeDelegatedLocked,
   StakeDelegatedWithdrawn,
   AllocationCollected,
+  RebateCollected,
   DelegationParametersUpdated,
   SlasherUpdate,
   AssetHolderUpdate,
@@ -24,7 +26,6 @@ import {
 import {
   Indexer,
   Allocation,
-  GraphNetwork,
   Pool,
   SubgraphDeployment,
   GraphAccount,
@@ -373,14 +374,18 @@ export function handleAllocationCreated(event: AllocationCreated): void {
   allocation.save()
 }
 
-// Transfers tokens from a state channel to the staking contract
-// Burns fees if protocolPercentage > 0
-// Collects curationFees to go to curator rewards
-// calls collect() on curation, which is handled in curation.ts
-// adds to the allocations collected fees
-// if closed, it will add fees to the rebate pool
-// Note - the name event.param.rebateFees is confusing. Rebate fees are better described
-// as query Fees. rebate is from cobbs douglas, which we get from claim()
+/** 
+ * @dev handleAllocationCollected
+ * Note: this handler is for the AllocationCollected event prior to exponential rebates upgrade
+ * - Transfers tokens from a state channel to the staking contract
+ * - Burns fees if protocolPercentage > 0
+ * - Collects curationFees to go to curator rewards
+ * - calls collect() on curation, which is handled in curation.ts
+ * - adds to the allocations collected fees
+ * - if closed, it will add fees to the rebate pool
+ * - Note - the name event.param.rebateFees is confusing. Rebate fees are better described
+ * as query Fees. rebate is from cobbs douglas, which we get from claim()
+*/
 export function handleAllocationCollected(event: AllocationCollected): void {
   let graphNetwork = createOrLoadGraphNetwork(event.block.number, event.address)
   let subgraphDeploymentID = event.params.subgraphDeploymentID.toHexString()
@@ -488,6 +493,73 @@ export function handleAllocationClosed(event: AllocationClosed): void {
   allocation.closedAtBlockNumber = (
     addresses.isL1 ? event.block.number : graphNetwork.currentL1BlockNumber!
   ).toI32()
+  allocation.status = 'Closed'
+  allocation.closedAt = event.block.timestamp.toI32()
+  allocation.poi = event.params.poi
+  allocation.indexingRewardCutAtClose = indexer.indexingRewardCut
+  allocation.indexingRewardEffectiveCutAtClose = indexer.indexingRewardEffectiveCut
+  allocation.queryFeeCutAtClose = indexer.queryFeeCut
+  allocation.queryFeeEffectiveCutAtClose = indexer.queryFeeEffectiveCut
+  allocation.save()
+
+  // update epoch - We do it here to have more epochs created, instead of seeing none created
+  // Likely this problem would go away with a live network with long epochs
+  // But we keep it here anyway. We might think of adding data in the future, like epoch.tokensClosed
+  let epoch = createOrLoadEpoch(
+    addresses.isL1 ? event.block.number : graphNetwork.currentL1BlockNumber!,
+  )
+  epoch.save()
+
+  // update subgraph deployment. Pretty sure this should be done here, if not
+  // it would be done in handleRebateClaimed
+  let subgraphDeploymentID = event.params.subgraphDeploymentID.toHexString()
+  let deployment = createOrLoadSubgraphDeployment(subgraphDeploymentID, event.block.timestamp)
+  deployment.stakedTokens = deployment.stakedTokens.minus(event.params.tokens)
+  deployment.save()
+
+  // update graph network
+  graphNetwork.totalTokensAllocated = graphNetwork.totalTokensAllocated.minus(event.params.tokens)
+  graphNetwork.save()
+}
+
+/**
+ * @dev handleAllocationClosed
+ * Note: this handler is for the AllocationClosed event prior to exponential rebates upgrade
+ * - update the indexers stake
+ * - update the subgraph total stake
+ * - update the named subgraph aggregate stake
+ * - update the specific allocation
+ * - update and close the channel
+ */
+export function handleAllocationClosedCobbDouglas(event: AllocationClosed1): void {
+  let graphNetwork = createOrLoadGraphNetwork(event.block.number, event.address)
+  let indexerID = event.params.indexer.toHexString()
+  let allocationID = event.params.allocationID.toHexString()
+
+  // update indexer
+  let indexer = Indexer.load(indexerID)!
+  const indexerAccount = GraphAccount.load(indexer.account)!
+  const closedByIndexer = event.params.sender == event.params.indexer
+  const closedByOperator = indexerAccount.operators.includes(event.params.sender.toHexString())
+
+  if (!closedByIndexer && !closedByOperator) {
+    indexer.forcedClosures = indexer.forcedClosures + 1
+  }
+  indexer.allocatedTokens = indexer.allocatedTokens.minus(event.params.tokens)
+  indexer.allocationCount = indexer.allocationCount - 1
+  indexer = updateAdvancedIndexerMetrics(indexer as Indexer)
+  indexer = calculateCapacities(indexer as Indexer)
+  indexer.save()
+
+  // update allocation
+  let allocation = Allocation.load(allocationID)!
+  allocation.poolClosedIn = event.params.epoch.toString()
+  allocation.activeForIndexer = null
+  allocation.closedAtEpoch = event.params.epoch.toI32()
+  allocation.closedAtBlockHash = event.block.hash
+  allocation.closedAtBlockNumber = (
+    addresses.isL1 ? event.block.number : graphNetwork.currentL1BlockNumber!
+  ).toI32()
   allocation.effectiveAllocation = event.params.effectiveAllocation
   allocation.status = 'Closed'
   allocation.closedAt = event.block.timestamp.toI32()
@@ -531,6 +603,7 @@ export function handleAllocationClosed(event: AllocationClosed): void {
 
 /**
  * @dev handleRebateClaimed
+ * Note: this handler is for the RebateClaimed event prior to exponential rebates upgrade
  * - update pool
  * - update closure of channel in pool
  * - update pool
@@ -558,7 +631,7 @@ export function handleRebateClaimed(event: RebateClaimed): void {
   let allocation = Allocation.load(allocationID)!
   allocation.queryFeeRebates = event.params.tokens
   allocation.delegationFees = event.params.delegationFees
-  allocation.status = 'Claimed'
+  allocation.status = 'Closed' // 'Claimed' is the correct status for pre exponential rebates
   allocation.save()
 
   // Update epoch
@@ -591,6 +664,89 @@ export function handleRebateClaimed(event: RebateClaimed): void {
   graphNetwork.save()
 }
 
+/** 
+ * @dev handleRebateCollected
+ * - update indexer
+ * - update allocation
+ * - update epoch
+ * - update subgraph deployment
+ * - update graph network
+*/
+export function handleRebateCollected(event: RebateCollected): void {
+  let graphNetwork = createOrLoadGraphNetwork(event.block.number, event.address)
+  let subgraphDeploymentID = event.params.subgraphDeploymentID.toHexString()
+  let indexerID = event.params.indexer.toHexString()
+  let allocationID = event.params.allocationID.toHexString()
+
+  // update indexer
+  let indexer = Indexer.load(indexerID)!
+  indexer.queryFeesCollected = indexer.queryFeesCollected.plus(event.params.queryFees)
+  indexer.queryFeeRebates = indexer.queryFeeRebates.plus(event.params.queryRebates)
+  indexer.delegatorQueryFees = indexer.delegatorQueryFees.plus(event.params.delegationRewards)
+  indexer.delegatedTokens = indexer.delegatedTokens.plus(event.params.delegationRewards)
+  if (indexer.delegatorShares != BigInt.fromI32(0)) {
+    indexer = updateDelegationExchangeRate(indexer as Indexer)
+  }
+  indexer = updateAdvancedIndexerMetrics(indexer as Indexer)
+  indexer.save()
+
+  // update allocation
+  // queryFees is the total token value minus the curation and protocol fees, as can be seen in the contracts
+  let allocation = Allocation.load(allocationID)!
+  allocation.queryFeesCollected = allocation.queryFeesCollected.plus(event.params.queryFees)
+  allocation.curatorRewards = allocation.curatorRewards.plus(event.params.curationFees)
+  allocation.queryFeeRebates = event.params.queryRebates
+  allocation.distributedRebates = allocation.distributedRebates.plus(event.params.queryRebates)
+  allocation.delegationFees = event.params.delegationRewards
+  allocation.status = 'Closed'
+  allocation.save()
+  
+  // Update epoch
+  let epoch = createOrLoadEpoch(
+    addresses.isL1 ? event.block.number : graphNetwork.currentL1BlockNumber!,
+  )
+  epoch.totalQueryFees = epoch.totalQueryFees.plus(event.params.tokens)
+  epoch.taxedQueryFees = epoch.taxedQueryFees.plus(event.params.protocolTax)
+  epoch.queryFeesCollected = epoch.queryFeesCollected.plus(event.params.queryFees)
+  epoch.curatorQueryFees = epoch.curatorQueryFees.plus(event.params.curationFees)
+  epoch.queryFeeRebates = epoch.queryFeeRebates.plus(event.params.queryRebates)
+  epoch.save()
+
+  // update subgraph deployment
+  let deployment = SubgraphDeployment.load(subgraphDeploymentID)!
+  deployment.queryFeesAmount = deployment.queryFeesAmount.plus(event.params.queryFees)
+  deployment.signalledTokens = deployment.signalledTokens.plus(event.params.curationFees)
+  deployment.curatorFeeRewards = deployment.curatorFeeRewards.plus(event.params.curationFees)
+  deployment.pricePerShare = calculatePricePerShare(deployment as SubgraphDeployment)
+  deployment.queryFeeRebates = deployment.queryFeeRebates.plus(event.params.queryRebates)
+  deployment.save()
+
+  batchUpdateSubgraphSignalledTokens(deployment as SubgraphDeployment)
+
+  // update graph network
+  graphNetwork.totalQueryFees = graphNetwork.totalQueryFees.plus(event.params.tokens)
+  graphNetwork.totalIndexerQueryFeesCollected = graphNetwork.totalIndexerQueryFeesCollected.plus(
+    event.params.queryFees,
+  )
+  graphNetwork.totalCuratorQueryFees = graphNetwork.totalCuratorQueryFees.plus(
+    event.params.curationFees,
+  )
+  graphNetwork.totalTaxedQueryFees = graphNetwork.totalTaxedQueryFees.plus(event.params.protocolTax)
+  graphNetwork.totalUnclaimedQueryFeeRebates = graphNetwork.totalUnclaimedQueryFeeRebates.plus(
+    event.params.queryFees,
+  )
+  graphNetwork.totalIndexerQueryFeeRebates = graphNetwork.totalIndexerQueryFeeRebates.plus(
+    event.params.queryRebates,
+  )
+  graphNetwork.totalDelegatorQueryFeeRebates = graphNetwork.totalDelegatorQueryFeeRebates.plus(
+    event.params.delegationRewards,
+  )
+  graphNetwork.totalUnclaimedQueryFeeRebates = graphNetwork.totalUnclaimedQueryFeeRebates.minus(
+    event.params.delegationRewards.plus(event.params.queryRebates),
+  )
+  graphNetwork.save()
+}
+
 /**
  * @dev handleParameterUpdated
  * - updates all parameters of staking, depending on string passed. We then can
@@ -614,10 +770,21 @@ export function handleParameterUpdated(event: ParameterUpdated): void {
   } else if (parameter == 'maxAllocationEpochs') {
     graphNetwork.maxAllocationEpochs = staking.maxAllocationEpochs().toI32()
   } else if (parameter == 'rebateRatio') {
+    // Cobbs-Douglas rebates
     graphNetwork.rebateRatio = staking
       .alphaNumerator()
       .toBigDecimal()
-      .div(staking.alphaDenominator().toBigDecimal()) // alphaDemoninator != 0, no div() protection needed
+      .div(staking.alphaDenominator().toBigDecimal()) // alphaDenominator != 0, no div() protection needed
+  } else if (parameter == 'rebateParameters') {
+    // Exponential rebates
+    graphNetwork.rebateAlpha = staking
+      .alphaNumerator()
+      .toBigDecimal()
+      .div(staking.alphaDenominator().toBigDecimal()) // alphaDenominator != 0, no div() protection needed
+    graphNetwork.rebateLambda = staking
+      .lambdaNumerator()
+      .toBigDecimal()
+      .div(staking.lambdaDenominator().toBigDecimal()) // lambdaDenominator!= 0, no div() protection needed
   } else if (parameter == 'delegationRatio') {
     graphNetwork.delegationRatio = staking.delegationRatio().toI32()
   } else if (parameter == 'delegationParametersCooldown') {

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -312,7 +312,7 @@ dataSources:
         - Epoch
       abis:
         - name: Staking
-          file: ./node_modules/@graphprotocol/contracts/dist/abis/IStaking.json
+          file: ./abis/IStakingStitched.json
         - name: GraphToken
           file: ./node_modules/@graphprotocol/contracts/dist/abis/GraphToken.json
         - name: EpochManager
@@ -339,11 +339,13 @@ dataSources:
         - event: AllocationCollected(indexed address,indexed bytes32,uint256,uint256,indexed address,address,uint256,uint256)
           handler: handleAllocationCollected
         - event: AllocationClosed(indexed address,indexed bytes32,uint256,uint256,indexed address,uint256,address,bytes32,bool)
+          handler: handleAllocationClosedCobbDouglas
+        - event: AllocationClosed(indexed address,indexed bytes32,uint256,uint256,indexed address,address,bytes32,bool)
           handler: handleAllocationClosed
-        # - event: AllocationClosed(indexed address,indexed bytes32,uint256,uint256,indexed address,uint256,address,bytes32,bool)
-        #   handler: handleAllocationClosed
         - event: RebateClaimed(indexed address,indexed bytes32,indexed address,uint256,uint256,uint256,uint256,uint256)
           handler: handleRebateClaimed
+        - event: RebateCollected(address,indexed address,indexed bytes32,indexed address,uint256,uint256,uint256,uint256,uint256,uint256,uint256)
+          handler: handleRebateCollected
         - event: SetOperator(indexed address,indexed address,bool)
           handler: handleSetOperator
         - event: SlasherUpdate(indexed address,indexed address,bool)
@@ -368,7 +370,7 @@ dataSources:
         - GraphNetwork
       abis:
         - name: StakingExtension
-          file: ./node_modules/@graphprotocol/contracts/dist/abis/StakingExtension.json
+          file: ./abis/StakingExtensionStitched.json
         - name: GraphToken
           file: ./node_modules/@graphprotocol/contracts/dist/abis/GraphToken.json
         - name: EpochManager

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,10 +419,10 @@
     graphql-import-node "^0.0.5"
     js-yaml "^4.1.0"
 
-"@graphprotocol/contracts@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/contracts/-/contracts-5.2.0.tgz#21a0fa0fd5c296fd3f60446b0cd244f765183ab1"
-  integrity sha512-4mTcU+f7Ig+DwYH9e0grlHCP+y5HHJ1QgSeKXVAB1rVHGJJ8Qdp0DVbkft+QVrJrQlAqobuNFsbt/9fyNmNwcA==
+"@graphprotocol/contracts@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/contracts/-/contracts-5.2.1.tgz#537e13697ca83c78498242706708b65550a656f7"
+  integrity sha512-32L6TN50hUcvVg5LDKQfUeJcrAN+sHMGEXVagMbJf9tLSCFAIheg0MPq0s9lQ+89GS1TJPA/fwwv8o268EtU4Q==
   dependencies:
     console-table-printer "^2.11.1"
     ethers "^5.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,10 +419,10 @@
     graphql-import-node "^0.0.5"
     js-yaml "^4.1.0"
 
-"@graphprotocol/contracts@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/contracts/-/contracts-5.0.0.tgz#b4602c2a4590c40a04238c9645b12e5816d7ef30"
-  integrity sha512-AxTJUz3atFyQSCoCY+YT1NLnrCJjTXsZSXO2lNnZwfTrs/W7Tkw/RJ9f4TWGjvtJ8aIJHS3suWjIWWqBWDR5aQ==
+"@graphprotocol/contracts@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/contracts/-/contracts-5.2.0.tgz#21a0fa0fd5c296fd3f60446b0cd244f765183ab1"
+  integrity sha512-4mTcU+f7Ig+DwYH9e0grlHCP+y5HHJ1QgSeKXVAB1rVHGJJ8Qdp0DVbkft+QVrJrQlAqobuNFsbt/9fyNmNwcA==
   dependencies:
     console-table-printer "^2.11.1"
     ethers "^5.6.0"


### PR DESCRIPTION
The following is a list of changes to the `Staking` and `RewardsManager` contract introduced by the exponential rebates upgrade and how they affect the network subgraph. All deprecated variables and entities should still be updated and valid up to the block where the exponential rebates upgrade was performed:

- Replace Cob-Douglass rebates with exponential rebates
   - [x] Add `lambdaNumerator` and `lambdaDenominator` to staking contract storage. For `alphaNumerator` and `alphaDenominator` we will re-use the storage variables currently in use for the Cobb-Douglas formula.
      - New variables in `GraphNetwork` entity: `rebateAlpha`, `rebateLambda`
      - Deprecated in `GraphNetwork` entity: `rebateRatio`
- Update `collect()` function to use exponential rebates
   - [x] Remove `claim()` function. Combine it with `collect()` in a single operation for better indexer UX. Replace `AllocationCollected` with `RebatesCollected` event
      - Added `RebatesCollected` event and handler combining logic from both previous events `AllocationCollected` and `RebateClaimed`
   - [x] Add `distributedRebates` to the `Allocation` struct to keep track of rebate distribution across multiple voucher collections.
      - Added `distributedRebates` variable to `Allocation` entity.
- Remove rebate pools 🥳 
   - [x] Deprecate `rebates` storage variable. Update `closeAllocation()` function to remove rebate pools logic.
      - Deprecated `Pool` entity and `poolClaimedIn` variable in `Allocation` entity.
      - Add a second `AllocationClosed` event and handler to match both event signatures (before and after upgrade).
   - [x] Deprecate `channelDisputeEpochs` storage variable and remove associated setters/getters
      - Deprecated in `GraphNetwork` entity: `channelDisputeEpochs`
   - [x] Deprecate `effectiveAllocation` in `Allocation` struct
      - Deprecated `effectiveAllocation` variable in `Allocation` entity.
   - [x] Remove `Claimed` and `Finalized` states from `Allocation` life cycle, affects `getAllocationState()`
      - Deprecated `Claimed` and `Finalized` states from `AllocationStatus` enum, which means `Allocation` entities variable `status` can no longer be in those two states. For consistency, this includes all history, even allocations claimed prior to the upgrade.
 